### PR TITLE
Add multi-leg flight support

### DIFF
--- a/init-db.sql
+++ b/init-db.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS routes (
     return_date TIMESTAMP WITH TIME ZONE,
     airline VARCHAR(100),
     flight_number VARCHAR(20),
+    legs JSONB DEFAULT '[]',
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(origin, destination, departure_date, flight_number)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   moduleNameMapper: {

--- a/src/components/AddRouteForm.tsx
+++ b/src/components/AddRouteForm.tsx
@@ -8,7 +8,8 @@ export const AddRouteForm = ({
     to: '',
     basePrice: '',
     duration: '',
-    distance: ''
+    distance: '',
+    stops: ''
   });
   const handleChange = e => {
     const {
@@ -22,13 +23,19 @@ export const AddRouteForm = ({
   };
   const handleSubmit = e => {
     e.preventDefault();
-    onAddRoute(routeData);
+    const legs = routeData.stops
+      ? [routeData.from, ...routeData.stops.split(',').map(s => s.trim()), routeData.to]
+          .slice(0, -1)
+          .map((from, idx, arr) => ({ from, to: arr[idx + 1] }))
+      : [{ from: routeData.from, to: routeData.to }];
+    onAddRoute({ ...routeData, legs });
     setRouteData({
       from: '',
       to: '',
       basePrice: '',
       duration: '',
-      distance: ''
+      distance: '',
+      stops: ''
     });
   };
   return <div>
@@ -69,6 +76,12 @@ export const AddRouteForm = ({
             </label>
             <input type="text" id="distance" name="distance" placeholder="e.g. 3,461 miles" value={routeData.distance} onChange={handleChange} className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" required />
           </div>
+        </div>
+        <div>
+          <label htmlFor="stops" className="block text-sm font-medium text-gray-700 mb-1">
+            Stops (comma separated)
+          </label>
+          <input type="text" id="stops" name="stops" placeholder="e.g. LHR,FCO" value={routeData.stops} onChange={handleChange} className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" />
         </div>
         <button type="submit" className="w-full flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-md transition-colors">
           <PlusCircleIcon className="h-5 w-5 mr-2" />

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -21,6 +21,7 @@ interface RouteCardProps {
     id: string;
     from: string;
     to: string;
+    legs?: { from: string; to: string }[];
     basePrice: number;
     prices: Array<{ date: string | Date; price: number }>;
     distance: string;
@@ -45,6 +46,7 @@ export const RouteCard: React.FC<RouteCardProps> = ({
   const {
     from,
     to,
+    legs,
     basePrice,
     prices,
     distance,
@@ -53,6 +55,9 @@ export const RouteCard: React.FC<RouteCardProps> = ({
   const lowestPrice = Math.min(...prices.map(p => p.price));
   const highestPrice = Math.max(...prices.map(p => p.price));
   const savings = basePrice - lowestPrice;
+  const path = legs && legs.length > 1
+    ? legs.map(l => l.from).concat(legs[legs.length - 1].to).join(' → ')
+    : `${from} → ${to}`;
   return <div className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
       <div className="flex flex-col space-y-4">
         <div className="flex justify-between items-start">
@@ -60,7 +65,7 @@ export const RouteCard: React.FC<RouteCardProps> = ({
             <div className="flex items-center space-x-2">
               <MapPinIcon className="h-5 w-5 text-blue-600" />
               <h3 className="text-lg font-semibold text-gray-800">
-                {from} <ArrowRightIcon className="inline h-4 w-4 mx-1" /> {to}
+                {path}
               </h3>
             </div>
             <div className="flex items-center text-sm text-gray-600 mt-1">
@@ -70,7 +75,10 @@ export const RouteCard: React.FC<RouteCardProps> = ({
               <span>{distance}</span>
             </div>
             <a 
-              href={getGoogleFlightsUrl(from, to)} 
+              href={getGoogleFlightsUrl(
+                legs && legs.length ? legs[0].from : from,
+                legs && legs.length ? legs[legs.length - 1].to : to
+              )}
               target="_blank" 
               rel="noopener noreferrer"
               className="flex items-center text-xs text-blue-600 mt-2 hover:text-blue-800 transition-colors"

--- a/src/components/__tests__/RouteCard.test.tsx
+++ b/src/components/__tests__/RouteCard.test.tsx
@@ -9,6 +9,7 @@ describe('RouteCard Component', () => {
     id: '1',
     from: 'JFK',
     to: 'LHR',
+    legs: [{ from: 'JFK', to: 'LHR' }],
     fromCity: 'New York',
     toCity: 'London',
     distance: 3461,
@@ -28,13 +29,8 @@ describe('RouteCard Component', () => {
   it('renders route information correctly', () => {
     render(<RouteCard route={sampleRoute} />);
     
-    // Check that route cities are displayed
-    expect(screen.getByText('New York')).toBeInTheDocument();
-    expect(screen.getByText('London')).toBeInTheDocument();
-    
-    // Check that airport codes are displayed
-    expect(screen.getByText('JFK')).toBeInTheDocument();
-    expect(screen.getByText('LHR')).toBeInTheDocument();
+    // Check that path is displayed
+    expect(screen.getByText('JFK → LHR')).toBeInTheDocument();
     
     // Check that flight details are displayed
     expect(screen.getByText('3,461 miles')).toBeInTheDocument();

--- a/src/config/defaultRoutes.ts
+++ b/src/config/defaultRoutes.ts
@@ -256,7 +256,31 @@ export const defaultRoutes: Omit<ApiRoute, 'id'>[] = [
       "toCode": "VIE",
       "source": "amadeus",
       "lowestPrice": 427.4,
-      "highestPrice": 627.2,
+    "highestPrice": 627.2,
+    "updatedAt": "2025-05-26T04:31:05.929Z"
+    }
+  },
+  {
+    "from": "New York (JFK)",
+    "to": "Rome (FCO)",
+    "legs": [
+      { "from": "New York (JFK)", "to": "London (LHR)", "distance": "3,442 mi", "duration": "7h 25m" },
+      { "from": "London (LHR)", "to": "Rome (FCO)", "distance": "890 mi", "duration": "2h 25m" }
+    ],
+    "basePrice": 390,
+    "prices": [
+      { "date": "2025-06-15T00:00:00.000Z", "price": 420 },
+      { "date": "2025-07-15T00:00:00.000Z", "price": 390 },
+      { "date": "2025-08-15T00:00:00.000Z", "price": 450 }
+    ],
+    "distance": "4,332 mi",
+    "duration": "9h 50m",
+    "meta": {
+      "fromCode": "JFK",
+      "toCode": "FCO",
+      "source": "amadeus",
+      "lowestPrice": 390,
+      "highestPrice": 450,
       "updatedAt": "2025-05-26T04:31:05.929Z"
     }
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { saveRoute as saveDbRoute, DbRoute } from './routeService';
+import { FlightLeg } from '../types/flight';
 
 // Interface for flight price data
 export interface FlightPrice {
@@ -36,6 +37,7 @@ export interface ApiRoute {
   id: string;
   from: string;
   to: string;
+  legs?: FlightLeg[];
   basePrice: number;
   prices: FlightPrice[];
   distance: string;
@@ -48,6 +50,7 @@ export interface Route extends Omit<ApiRoute, 'meta'> {
   id: string;
   from: string;
   to: string;
+  legs?: FlightLeg[];
   prices: Array<{ date: string | Date; price: number }>;
   basePrice: number;
   distance: string;
@@ -75,7 +78,8 @@ const toDbRoute = (route: ApiRoute): Omit<DbRoute, 'id' | 'created_at' | 'update
     departure_date: departureDate,
     return_date: returnDate,
     airline: 'Unknown',
-    flight_number: `FLT-${Math.floor(1000 + Math.random() * 9000)}`
+    flight_number: `FLT-${Math.floor(1000 + Math.random() * 9000)}`,
+    legs: route.legs || []
   };
 };
 
@@ -144,6 +148,7 @@ const toApiRoute = (dbRoute: DbRoute): ApiRoute => {
       id: dbRoute.id?.toString() || `temp-${Date.now()}`,
       from: origin,
       to: destination,
+      legs: dbRoute.legs && Array.isArray(dbRoute.legs) ? dbRoute.legs : [{ from: origin, to: destination }],
       basePrice: price,
       distance: '0 km',
       duration: '0h 0m',

--- a/src/types/flight.ts
+++ b/src/types/flight.ts
@@ -15,3 +15,10 @@ export interface FlightPriceResult {
   currency: string;
   flightNumber?: string;
 }
+
+export interface FlightLeg {
+  from: string;
+  to: string;
+  distance?: string;
+  duration?: string;
+}


### PR DESCRIPTION
## Summary
- support multi-leg flights in data model
- allow input of intermediate stops when adding a route
- display full route path in `RouteCard`
- include sample multi-leg route in defaults
- update database schema and types

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: ResizeObserver not defined and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_6848dd129e58832eab55bed9aeded479