### PR TITLE
Make API base configurable and convert Netlify functions to ESM

### DIFF
--- a/netlify/functions/flight-prices.js
+++ b/netlify/functions/flight-prices.js
@@ -1,4 +1,4 @@
-const Amadeus = require('amadeus');
+import Amadeus from 'amadeus';
 
 // Initialize Amadeus client with environment variables
 const amadeus = new Amadeus({
@@ -65,7 +65,7 @@ const getFlightPricesForDates = async (origin, destination, dates) => {
   return prices.filter(price => price.price !== null);
 };
 
-exports.handler = async (event, context) => {
+export const handler = async (event, context) => {
   // Set CORS headers
   const headers = {
     'Access-Control-Allow-Origin': '*',

--- a/netlify/functions/popular-routes.js
+++ b/netlify/functions/popular-routes.js
@@ -1,4 +1,4 @@
-const Amadeus = require('amadeus');
+import Amadeus from 'amadeus';
 
 // Initialize Amadeus client with environment variables
 const amadeus = new Amadeus({
@@ -317,7 +317,7 @@ const getFlightInfo = async (origin, destination) => {
   };
 };
 
-exports.handler = async (event, context) => {
+export const handler = async (event, context) => {
   // Set CORS headers
   const headers = {
     'Access-Control-Allow-Origin': '*',

--- a/netlify/functions/search-flights.js
+++ b/netlify/functions/search-flights.js
@@ -1,6 +1,6 @@
-const Amadeus = require('amadeus');
+import Amadeus from 'amadeus';
 
-exports.handler = async (event, context) => {
+export const handler = async (event, context) => {
   // Only allow POST requests
   if (event.httpMethod !== 'POST') {
     return {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -19,9 +19,11 @@ export interface RouteMeta {
 }
 
 // API configuration
-const API_BASE_URL = process.env.NODE_ENV === 'production' 
-  ? 'https://apollo-route-manager.windsurf.build/.netlify/functions'
-  : 'http://localhost:8889/.netlify/functions';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  (import.meta.env.DEV
+    ? 'http://localhost:8889/.netlify/functions'
+    : '/.netlify/functions');
 
 // Create axios instance with default configuration
 export const apiClient = axios.create({

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -5,10 +5,12 @@ export interface QueryResult<T> {
   rowCount: number;
 }
 
-// In development, use the same origin as the frontend since they're served together
-const API_BASE_URL = process.env.NODE_ENV === 'production'
-  ? '/.netlify/functions'
-  : '/.netlify/functions';
+// API configuration
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  (import.meta.env.DEV
+    ? 'http://localhost:8889/.netlify/functions'
+    : '/.netlify/functions');
 
 /**
  * Executes a database query and returns the result

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- Derive API base URL from `VITE_API_BASE_URL` with sensible dev/prod defaults
- Convert Netlify functions using Amadeus to ES module `import`/`export`
- Add Vite env type declarations so `import.meta.env` is typed

## Testing
- `npm test` *(fails: SyntaxError in jest.config.cjs)*
- `npm run lint` *(fails: 78 problems, 76 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688e3445141c832e91e1e1282cfb748a