### PR TITLE
Change CI/CD to use preview deploys for PRs

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Deploy Preview to Netlify
         id: deploy-preview
         run: |
-          OUTPUT=$(netlify deploy --dir=dist --functions=netlify/functions --site ${{ secrets.NETLIFY_SITE_ID_GAMMA }} --json --build=false)
+          OUTPUT=$(netlify deploy --dir=dist --functions=netlify/functions --site ${{ secrets.NETLIFY_SITE_ID_GAMMA }} --json --no-build)
           echo "$OUTPUT"
           DEPLOY_URL=$(echo "$OUTPUT" | jq -r '.deploy_url')
           echo "deploy_url=$DEPLOY_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- PRs now create unique preview URLs (e.g., `https://682abc123--route-manager-gamma.netlify.app/`) instead of deploying directly to Gamma
- Gamma site only updates on merge to main
- Preview URL is automatically commented on each PR

## Changes
- Separated build into reusable job with artifact upload
- Added `deploy-preview` job for PRs using `netlify deploy` without `--prod`
- `deploy-gamma` now only runs on push to main/master
- Automatic PR comment with preview link

## Test plan
- [ ] Open a PR and verify preview URL is generated and commented
- [ ] Verify Gamma site is not updated until PR is merged
- [ ] Merge PR and verify Gamma deploys correctly