### PR TITLE
Horizon UI, planning canvas, API runtime, and Netlify workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# Copy to .env — never commit real secrets.
+
+# --- Amadeus (functions) ---
+AMADEUS_API_KEY=
+AMADEUS_API_SECRET=
+AMADEUS_HOSTNAME=production
+
+# Skip live Amadeus in netlify functions (fast local API smoke tests)
+# USE_MOCK_DATA=true
+
+# --- Postgres (functions + scripts) ---
+DB_USER=routeuser
+DB_PASSWORD=routepass
+DB_NAME=routedb
+DB_HOST=localhost
+DB_PORT=5432
+
+# --- Vite client (prefix VITE_ is exposed to the browser) ---
+# Same-origin Netlify functions (default when using netlify dev)
+# VITE_API_URL=/.netlify/functions
+
+# Pure in-memory mock in the browser — no HTTP to functions for prices
+# VITE_API_MODE=mock
+
+# Point the SPA at a remote mock or staging API (full URL including path to functions)
+# VITE_API_MODE=remote
+# VITE_REMOTE_API_BASE=https://your-mock-host.example.com/.netlify/functions
+
+# Skip Postgres-backed getRoutes; instant seeded routes in the UI
+# VITE_USE_MOCK_ROUTES=true
+
+# Optional: tighter client timeout (ms)
+# VITE_API_TIMEOUT_MS=12000

--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -20,6 +20,7 @@ on:
         type: choice
         options:
           - alpha
+          - gamma
           - prod
 
 env:
@@ -92,6 +93,45 @@ jobs:
           curl --fail --silent --show-error "https://route-manager-alpha.netlify.app/.netlify/functions/test-env" || echo "test-env endpoint failed (non-blocking)";
           echo "Testing /search-flights endpoint (ignore errors):";
           curl --fail --silent --show-error "https://route-manager-alpha.netlify.app/.netlify/functions/search-flights" || echo "search-flights endpoint failed (non-blocking)";
+
+  deploy-gamma:
+    runs-on: ubuntu-latest
+    needs: determine-environment
+    if: needs.determine-environment.outputs.target_env == 'gamma'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: List Netlify functions before deploy
+        run: |
+          echo "Listing functions in netlify/functions:";
+          find ./netlify/functions -type f -name "*.js" -exec echo " - {}" \;
+
+      - name: Install Netlify CLI
+        run: npm install -g netlify-cli
+
+      - name: Deploy to Gamma (staging)
+        run: netlify deploy --dir=dist --prod --site ${{ secrets.NETLIFY_SITE_ID_GAMMA }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+
+      - name: (Non-blocking) Test deployed functions
+        run: |
+          echo "Testing /health endpoint (ignore errors):";
+          curl --fail --silent --show-error "https://route-manager-gamma.netlify.app/.netlify/functions/health" || echo "health endpoint failed (non-blocking)";
+          echo "Testing /flight-prices endpoint (ignore errors):";
+          curl --fail --silent --show-error "https://route-manager-gamma.netlify.app/.netlify/functions/flight-prices?from=JFK&to=LAX" || echo "flight-prices endpoint failed (non-blocking)";
 
   deploy-prod:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ cdk/dist
 cdk/cdk.out
 *.js.map
 *.d.ts
+!src/vite-env.d.ts

--- a/index.html
+++ b/index.html
@@ -4,9 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <meta name="theme-color" content="#0c1222" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,400;0,500;0,600;0,700;1,500&display=swap" rel="stylesheet" />
+    <title>Apollo Flight Trader</title>
   </head>
-  <body>
+  <body class="font-sans antialiased">
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,14 +1,23 @@
-export default {
+/** @type {import('jest').Config} */
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   moduleNameMapper: {
-    // Handle CSS imports (with CSS modules)
     '\\.css$': 'identity-obj-proxy',
   },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   testPathIgnorePatterns: ['/node_modules/'],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          module: 'commonjs',
+          moduleResolution: 'node',
+          esModuleInterop: true,
+        },
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,8 @@
     NODE_ENV = "development"
     VITE_API_URL = "/.netlify/functions"
     CORS_ORIGIN = "http://localhost:5173"
+    # Set to "true" locally to exercise flight-prices without Amadeus (see .env.example)
+    # USE_MOCK_DATA = "false"
 
     # These will be loaded from .env file or system environment
     AMADEUS_API_KEY = "${AMADEUS_API_KEY}"

--- a/netlify/functions/flight-prices.js
+++ b/netlify/functions/flight-prices.js
@@ -1,4 +1,5 @@
 import Amadeus from 'amadeus';
+import { getFlightPricesForDates } from './lib/amadeusBatch.js';
 
 // Helper function to get config with fallbacks
 const getConfig = async () => {
@@ -50,63 +51,62 @@ const generateDatesForNextMonth = () => {
   return dates;
 };
 
-// Function to get flight prices for multiple dates
-const getFlightPricesForDates = async (origin, destination, dates) => {
-  const pricePromises = dates.map(async (date) => {
-    try {
-      // Search for flight offers
-      const response = await amadeus.shopping.flightOffersSearch.get({
-        originLocationCode: origin,
-        destinationLocationCode: destination,
-        departureDate: date,
-        adults: '1',
-        max: '1', // Only get the cheapest offer
-        currencyCode: 'USD'
-      });
-      
-      // Log the raw Amadeus API response
-      console.log(`Amadeus API response for ${origin} to ${destination} on ${date}:`, JSON.stringify(response, null, 2));
-
-      // Extract the price and flight details from the response
-      if (response.data && response.data.length > 0) {
-        const flight = response.data[0];
-        const price = parseFloat(flight.price.total);
-
-        // Extract flight details
-        const firstSegment = flight.itineraries[0].segments[0];
-        const lastSegment = flight.itineraries[0].segments[flight.itineraries[0].segments.length - 1];
-
-        return {
-          date,
-          price,
-          flightDetails: {
-            carrier: firstSegment.carrierCode,
-            flightNumber: `${firstSegment.carrierCode}${firstSegment.number}`,
-            departureTime: firstSegment.departure.at,
-            arrivalTime: lastSegment.arrival.at,
-            duration: flight.itineraries[0].duration,
-            stops: flight.itineraries[0].segments.length - 1,
-            bookingClass: flight.travelerPricings?.[0]?.fareDetailsBySegment?.[0]?.cabin || 'ECONOMY'
-          }
-        };
-      }
-
-      // If no offers found, return null
-      return { date, price: null };
-    } catch (error) {
-      console.error(`Error fetching price for ${date}:`, error);
-      return { date, price: null };
-    }
-  });
-  
-  // Wait for all price requests to complete
-  const prices = await Promise.all(pricePromises);
-  
-  // Filter out null prices and return the results
-  return prices.filter(price => price.price !== null);
-};
-
 export const handler = async (event, context) => {
+  const origin = event.headers.origin || event.headers.Origin || '';
+  const allowedOrigins = [
+    'http://localhost:5173',
+    'http://localhost:3000',
+    'https://apollo-route-manager.windsurf.build',
+    'https://route-manager-demo.netlify.app',
+  ];
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': allowedOrigins.includes(origin) ? origin : allowedOrigins[2],
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Credentials': 'true',
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: corsHeaders, body: '' };
+  }
+
+  // Skip Amadeus entirely — fast local/staging UI without credentials (netlify.toml or .env)
+  if (process.env.USE_MOCK_DATA === 'true' || process.env.AMADEUS_MOCK === '1') {
+    const params = event.queryStringParameters || {};
+    const from = params.from || 'JFK';
+    const to = params.to || 'LAX';
+    const dates = generateDatesForNextMonth();
+    const basePrice = 400 + ((from.charCodeAt(0) + to.charCodeAt(0)) % 400);
+    const mockPrices = dates.map((date, index) => ({
+      date,
+      price: Math.round(basePrice + Math.sin(index / 5) * 40 + (index % 7) * 3),
+      flightDetails: {
+        carrier: 'MOCK',
+        flightNumber: 'MOCK100',
+        departureTime: `${date}T08:00:00`,
+        arrivalTime: `${date}T16:00:00`,
+        duration: 'PT6H',
+        stops: 0,
+        bookingClass: 'ECONOMY',
+      },
+    }));
+    return {
+      statusCode: 200,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json',
+        'X-Data-Source': 'mock-env',
+      },
+      body: JSON.stringify({
+        prices: mockPrices,
+        basePrice: mockPrices[0]?.price ?? basePrice,
+        lowestPrice: Math.min(...mockPrices.map((p) => p.price)),
+        highestPrice: Math.max(...mockPrices.map((p) => p.price)),
+        source: 'mock',
+      }),
+    };
+  }
+
   // Initialize Amadeus client if not already initialized
   if (!amadeus) {
     console.log('Initializing Amadeus client...');
@@ -127,31 +127,8 @@ export const handler = async (event, context) => {
     NODE_ENV: process.env.NODE_ENV || 'Not set'
   });
 
-  // Set CORS headers - allow both localhost and production
-  const origin = event.headers.origin || event.headers.Origin || '';
-  const allowedOrigins = [
-    'http://localhost:5173',
-    'http://localhost:3000',
-    'https://apollo-route-manager.windsurf.build',
-    'https://route-manager-demo.netlify.app'
-  ];
+  const headers = corsHeaders;
 
-  const headers = {
-    'Access-Control-Allow-Origin': allowedOrigins.includes(origin) ? origin : allowedOrigins[2],
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Credentials': 'true',
-  };
-  
-  // Handle preflight OPTIONS request
-  if (event.httpMethod === 'OPTIONS') {
-    return {
-      statusCode: 200,
-      headers,
-      body: ''
-    };
-  }
-  
   try {
     // Parse request parameters
     const params = event.queryStringParameters || {};
@@ -188,7 +165,7 @@ export const handler = async (event, context) => {
     const dates = generateDatesForNextMonth();
     
     // Get flight prices for all dates
-    const prices = await getFlightPricesForDates(originCode, destinationCode, dates);
+    const prices = await getFlightPricesForDates(amadeus, originCode, destinationCode, dates);
     
     // If no prices found, return an error
     if (prices.length === 0) {
@@ -217,7 +194,7 @@ export const handler = async (event, context) => {
       });
       
       // Log the mock fallback data
-      console.log(`Mock fallback data for ${origin} to ${destination}:`, JSON.stringify(mockPrices, null, 2));
+      console.log(`Mock fallback data for ${originCode} to ${destinationCode}:`, JSON.stringify(mockPrices, null, 2));
       return {
         statusCode: 200,
         headers,

--- a/netlify/functions/lib/amadeusBatch.js
+++ b/netlify/functions/lib/amadeusBatch.js
@@ -1,0 +1,52 @@
+/**
+ * Shared Amadeus batched date pricing — used by flight-prices and popular-routes.
+ * @param {import('amadeus').default} amadeus
+ * @param {string} origin
+ * @param {string} destination
+ * @param {string[]} dates
+ */
+export async function getFlightPricesForDates(amadeus, origin, destination, dates) {
+  const pricePromises = dates.map(async (date) => {
+    try {
+      const response = await amadeus.shopping.flightOffersSearch.get({
+        originLocationCode: origin,
+        destinationLocationCode: destination,
+        departureDate: date,
+        adults: '1',
+        max: '1',
+        currencyCode: 'USD',
+      });
+
+      if (response.data && response.data.length > 0) {
+        const flight = response.data[0];
+        const price = parseFloat(flight.price.total);
+        const firstSegment = flight.itineraries[0].segments[0];
+        const lastSegment =
+          flight.itineraries[0].segments[flight.itineraries[0].segments.length - 1];
+
+        return {
+          date,
+          price,
+          flightDetails: {
+            carrier: firstSegment.carrierCode,
+            flightNumber: `${firstSegment.carrierCode}${firstSegment.number}`,
+            departureTime: firstSegment.departure.at,
+            arrivalTime: lastSegment.arrival.at,
+            duration: flight.itineraries[0].duration,
+            stops: flight.itineraries[0].segments.length - 1,
+            bookingClass:
+              flight.travelerPricings?.[0]?.fareDetailsBySegment?.[0]?.cabin || 'ECONOMY',
+          },
+        };
+      }
+
+      return { date, price: null };
+    } catch (error) {
+      console.error(`Error fetching price for ${date}:`, error);
+      return { date, price: null };
+    }
+  });
+
+  const prices = await Promise.all(pricePromises);
+  return prices.filter((p) => p.price !== null);
+}

--- a/netlify/functions/popular-routes.js
+++ b/netlify/functions/popular-routes.js
@@ -1,4 +1,5 @@
 import Amadeus from 'amadeus';
+import { getFlightPricesForDates } from './lib/amadeusBatch.js';
 
 // Helper function to get config with fallbacks
 const getConfig = async () => {
@@ -407,7 +408,12 @@ export const handler = async (event, context) => {
         // First try to get real flight data
         try {
           console.log(`Fetching real flight data for ${route.code1} to ${route.code2}`);
-          const realPrices = await getFlightPricesForDates(route.code1, route.code2, generateDatesForNextMonth());
+          const realPrices = await getFlightPricesForDates(
+            amadeus,
+            route.code1,
+            route.code2,
+            generateDatesForNextMonth()
+          );
           
           if (realPrices && realPrices.length > 0) {
             // Sort by price and get the cheapest

--- a/package-lock.json
+++ b/package-lock.json
@@ -12226,9 +12226,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -12238,9 +12236,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -12249,9 +12245,7 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -12263,9 +12257,7 @@
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
       "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -12321,9 +12313,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "16.11.22",
@@ -12341,17 +12331,13 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
@@ -12363,9 +12349,7 @@
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
+      "extraneous": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "load-default-routes": "tsx scripts/loadDefaultRoutes.ts",
     "load-prices": "tsx scripts/loadPrices.ts",
     "test-single-route": "tsx scripts/testSingleRoute.ts",
-    "test-all-routes": "tsx scripts/testAllRoutes.ts"
+    "test-all-routes": "tsx scripts/testAllRoutes.ts",
+    "test:functions-local": "node scripts/test-local-functions.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/scripts/test-local-functions.mjs
+++ b/scripts/test-local-functions.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Smoke-test Netlify functions locally without deploying.
+ * Start the stack first: npm run dev:clean   (netlify.toml uses port 3000 for the dev server)
+ *
+ * Usage:
+ *   node scripts/test-local-functions.mjs
+ *   BASE_URL=http://localhost:8888 node scripts/test-local-functions.mjs
+ */
+
+const base = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+
+const paths = [
+  '/.netlify/functions/health',
+  '/.netlify/functions/flight-prices?from=JFK&to=LAX',
+];
+
+async function main() {
+  console.log(`Probing ${base} …\n`);
+  for (const p of paths) {
+    const url = `${base}${p}`;
+    const t0 = performance.now();
+    try {
+      const res = await fetch(url, { headers: { Accept: 'application/json' } });
+      const ms = Math.round(performance.now() - t0);
+      const text = await res.text();
+      let body = text;
+      try {
+        body = JSON.stringify(JSON.parse(text), null, 0);
+      } catch {
+        /* not JSON */
+      }
+      console.log(`${res.status} ${ms}ms  ${p}`);
+      if (!res.ok) console.log(body.slice(0, 500));
+    } catch (e) {
+      console.error(`FAIL ${p}`, e.message);
+    }
+  }
+  console.log('\nTip: set USE_MOCK_DATA=true in .env for flight-prices without Amadeus.');
+}
+
+main();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,60 +1,123 @@
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { PlaneTakeoffIcon, Loader2 } from 'lucide-react';
+import { BrowserRouter as Router, Routes, Route, NavLink } from 'react-router-dom';
+import { lazy, Suspense, useEffect, useState } from 'react';
+import { Loader2, Plane } from 'lucide-react';
 
-// Import page components
 import HomePage from './pages/HomePage';
 import SearchFlightsPage from './pages/SearchFlightsPage';
 import PriceTrendsPage from './pages/PriceTrendsPage';
 
+const PlanningPage = lazy(() => import('./pages/PlanningPage'));
+
+function prefetchPlanningChunk() {
+  void import('./pages/PlanningPage');
+}
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  [
+    'rounded-full px-3.5 py-2 text-sm font-medium transition-colors duration-200',
+    isActive
+      ? 'bg-white/10 text-white shadow-inner shadow-white/5'
+      : 'text-slate-400 hover:bg-white/5 hover:text-white',
+  ].join(' ');
+
 function AppContent() {
   const [isLoading, setIsLoading] = useState(false);
 
-  // For now, we'll skip the initial loading since we're using mock data
   useEffect(() => {
     setIsLoading(false);
   }, []);
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="flex min-h-screen items-center justify-center bg-[hsl(var(--background))]">
         <div className="text-center">
-          <Loader2 className="h-12 w-12 text-blue-600 animate-spin mx-auto mb-4" />
-          <p className="text-lg font-medium text-gray-900">Loading application...</p>
+          <Loader2 className="mx-auto mb-4 h-12 w-12 animate-spin text-cyan-400" aria-hidden />
+          <p className="font-medium text-slate-300">Loading…</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex items-center justify-between">
-            <Link to="/" className="flex items-center">
-              <PlaneTakeoffIcon className="h-8 w-8 text-blue-600" />
-              <h1 className="ml-3 text-xl font-bold text-gray-900">Flight Route Manager</h1>
-            </Link>
-            <nav className="hidden md:flex space-x-8">
-              <Link to="/" className="text-gray-500 hover:text-gray-700 font-medium">Home</Link>
-              <Link to="/search" className="text-gray-500 hover:text-gray-700 font-medium">Search Flights</Link>
-              <Link to="/trends" className="text-gray-500 hover:text-gray-700 font-medium">Price Trends</Link>
-            </nav>
-          </div>
+    <div className="flex min-h-screen flex-col bg-transparent">
+      <header className="sticky top-0 z-50 border-b border-white/5 bg-slate-950/75 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
+          <NavLink to="/" className="group flex items-center gap-2.5 outline-none ring-cyan-400/50 focus-visible:ring-2">
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-400/20 to-amber-400/15 ring-1 ring-white/10 transition group-hover:from-cyan-400/30">
+              <Plane className="h-5 w-5 text-cyan-300" aria-hidden />
+            </span>
+            <span className="flex flex-col leading-tight">
+              <span className="text-sm font-semibold tracking-tight text-white">Apollo</span>
+              <span className="text-[11px] font-medium uppercase tracking-[0.2em] text-slate-500">Flight Trader</span>
+            </span>
+          </NavLink>
+
+          <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
+            <NavLink to="/" className={navLinkClass} end>
+              Home
+            </NavLink>
+            <NavLink to="/plan" className={navLinkClass} onPointerEnter={prefetchPlanningChunk}>
+              Plan
+            </NavLink>
+            <NavLink to="/search" className={navLinkClass}>
+              Search
+            </NavLink>
+            <NavLink to="/trends" className={navLinkClass}>
+              Trends
+            </NavLink>
+          </nav>
+        </div>
+
+        <div className="border-t border-white/5 px-4 py-2 md:hidden">
+          <nav className="flex flex-wrap justify-center gap-1" aria-label="Primary mobile">
+            <NavLink to="/" className={navLinkClass} end>
+              Home
+            </NavLink>
+            <NavLink to="/plan" className={navLinkClass} onPointerEnter={prefetchPlanningChunk}>
+              Plan
+            </NavLink>
+            <NavLink to="/search" className={navLinkClass}>
+              Search
+            </NavLink>
+            <NavLink to="/trends" className={navLinkClass}>
+              Trends
+            </NavLink>
+          </nav>
         </div>
       </header>
 
-      <main>
+      <main className="relative flex-1">
         <Routes>
-          <Route path="/" element={
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-              <HomePage />
-            </div>
-          } />
+          <Route
+            path="/"
+            element={
+              <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+                <HomePage />
+              </div>
+            }
+          />
           <Route path="/search" element={<SearchFlightsPage />} />
           <Route path="/trends" element={<PriceTrendsPage />} />
+          <Route
+            path="/plan"
+            element={
+              <Suspense
+                fallback={
+                  <div className="flex min-h-[50vh] items-center justify-center">
+                    <Loader2 className="h-10 w-10 animate-spin text-cyan-400" aria-hidden />
+                  </div>
+                }
+              >
+                <PlanningPage />
+              </Suspense>
+            }
+          />
         </Routes>
       </main>
+
+      <footer className="mt-auto border-t border-white/5 py-6 text-center text-xs text-slate-500">
+        Price signals for planning — not a booking engine.
+      </footer>
     </div>
   );
 }

--- a/src/components/__tests__/RouteCard.test.tsx
+++ b/src/components/__tests__/RouteCard.test.tsx
@@ -25,13 +25,10 @@ describe('RouteCard Component', () => {
   it('renders route information correctly', () => {
     render(<RouteCard route={sampleRoute} />);
     
-    // Check that route cities are displayed
-    expect(screen.getByText('New York')).toBeInTheDocument();
-    expect(screen.getByText('London')).toBeInTheDocument();
-    
-    // Check that airport codes are displayed
-    expect(screen.getByText('JFK')).toBeInTheDocument();
-    expect(screen.getByText('LHR')).toBeInTheDocument();
+    // Cities are in a single heading with inline icons (not plain text nodes)
+    const title = screen.getByRole('heading', { level: 3 });
+    expect(title).toHaveTextContent('New York');
+    expect(title).toHaveTextContent('London');
     
     // Check that flight details are displayed
     expect(screen.getByText('3,461 miles')).toBeInTheDocument();

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -1,0 +1,35 @@
+/**
+ * Client-side API runtime: Netlify functions (default), in-memory mock, or remote mock/staging URL.
+ * Aligns with netlify.toml [dev.environment] VITE_API_URL.
+ */
+
+export type ApiMode = 'netlify' | 'mock' | 'remote';
+
+export function getApiMode(): ApiMode {
+  const m = import.meta.env.VITE_API_MODE;
+  if (m === 'mock' || m === 'remote') return m;
+  return 'netlify';
+}
+
+/** Axios baseURL: relative path for same-origin, or absolute URL for remote mocks */
+export function getApiBaseUrl(): string {
+  if (getApiMode() === 'remote') {
+    const remote = import.meta.env.VITE_REMOTE_API_BASE?.trim();
+    if (remote) return remote.replace(/\/$/, '');
+  }
+  const fromEnv =
+    import.meta.env.VITE_API_URL?.trim() ||
+    import.meta.env.VITE_API_BASE_URL?.trim();
+  if (fromEnv) return fromEnv.replace(/\/$/, '');
+  return '/.netlify/functions';
+}
+
+export function getApiTimeoutMs(): number {
+  const n = Number(import.meta.env.VITE_API_TIMEOUT_MS);
+  return Number.isFinite(n) && n > 0 ? n : 20_000;
+}
+
+/** When true, skip Postgres-backed getRoutes and use seeded routes (fast UI / tests). */
+export function mockRoutesFromEnv(): boolean {
+  return import.meta.env.VITE_USE_MOCK_ROUTES === 'true';
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,59 +1,85 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
- 
+
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
+    /* Dark “horizon” shell — sky cyan + warm amber accents */
+    --background: 222 47% 7%;
+    --foreground: 210 40% 96%;
+    --card: 222 35% 11%;
+    --card-foreground: 210 40% 96%;
+    --popover: 222 35% 12%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 187 78% 52%;
+    --primary-foreground: 222 47% 8%;
+    --secondary: 217 33% 17%;
+    --secondary-foreground: 210 40% 92%;
+    --muted: 217 33% 16%;
+    --muted-foreground: 215 20% 62%;
+    --accent: 38 92% 50%;
+    --accent-foreground: 222 47% 8%;
+    --destructive: 0 72% 51%;
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.5rem;
+    --border: 217 33% 18%;
+    --input: 217 33% 18%;
+    --ring: 187 78% 52%;
+    --radius: 0.75rem;
   }
- 
+
   .dark {
-    --background: 222.2 84% 4.9%;
+    --background: 222 47% 6%;
     --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
+    --card: 222 35% 10%;
     --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
+    --popover: 222 35% 10%;
     --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
+    --primary: 187 78% 55%;
+    --primary-foreground: 222 47% 8%;
+    --secondary: 217 33% 17%;
     --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --muted: 217 33% 17%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 38 92% 50%;
+    --accent-foreground: 222 47% 8%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    --border: 217 33% 18%;
+    --input: 217 33% 18%;
+    --ring: 187 78% 55%;
   }
 }
- 
+
 @layer base {
   * {
-    @apply border-gray-200;
+    @apply border-border;
   }
+
+  html {
+    @apply scroll-smooth;
+  }
+
   body {
-    @apply bg-white text-gray-900;
+    @apply min-h-screen font-sans text-foreground antialiased;
+    background-color: hsl(var(--background));
+    background-image:
+      radial-gradient(ellipse 130% 90% at 50% -25%, rgba(34, 211, 238, 0.14), transparent 55%),
+      radial-gradient(ellipse 70% 80% at 100% 0%, rgba(251, 191, 36, 0.07), transparent 50%),
+      radial-gradient(ellipse 55% 45% at 0% 100%, rgba(129, 140, 248, 0.1), transparent 50%),
+      radial-gradient(ellipse 100% 60% at 50% 100%, rgba(15, 23, 42, 0.9), transparent);
+    background-attachment: fixed;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  }
+}
+
+/* Light panels for forms (search / trends) — paper on dark sky */
+@layer components {
+  .surface-paper {
+    @apply rounded-2xl border border-white/10 bg-white/95 text-slate-900 shadow-xl shadow-slate-950/40 backdrop-blur-sm;
   }
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,37 +1,119 @@
+import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
+import { ArrowUpRight, Compass, LineChart, Plane, Sparkles } from 'lucide-react';
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
-      <div className="max-w-4xl mx-auto text-center">
-        <h1 className="text-4xl font-bold text-gray-900 mb-8">Flight Route Manager</h1>
-        <p className="text-lg text-gray-600 mb-12">Track and analyze flight prices across different routes</p>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <Card
-            title="Search Flights"
-            description=""
+    <div className="space-y-16 lg:space-y-24">
+      <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-slate-900/80 via-slate-900/40 to-slate-950/60 px-6 py-14 shadow-2xl shadow-cyan-950/20 sm:px-10 sm:py-20 lg:px-16">
+        <div
+          className="pointer-events-none absolute -right-20 -top-20 h-72 w-72 rounded-full bg-cyan-500/10 blur-3xl"
+          aria-hidden
+        />
+        <div
+          className="pointer-events-none absolute -bottom-16 -left-16 h-64 w-64 rounded-full bg-amber-400/5 blur-3xl"
+          aria-hidden
+        />
+
+        <p className="mb-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.25em] text-cyan-400/90">
+          <Sparkles className="h-3.5 w-3.5" aria-hidden />
+          Route intelligence
+        </p>
+        <h1 className="max-w-3xl text-4xl font-bold leading-[1.1] tracking-tight text-white sm:text-5xl lg:text-6xl">
+          See the window before you commit.
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-400">
+          Compare corridors, watch price pressure, and plan trips with context — not just a list of fares.
+        </p>
+        <div className="mt-10 flex flex-wrap gap-3">
+          <Link
+            to="/plan"
+            className="inline-flex items-center gap-2 rounded-full bg-cyan-400 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/25 transition hover:bg-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          >
+            Open trip canvas
+            <ArrowUpRight className="h-4 w-4" aria-hidden />
+          </Link>
+          <Link
             to="/search"
+            className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-6 py-3 text-sm font-semibold text-white backdrop-blur-sm transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
+          >
+            Search flights
+          </Link>
+        </div>
+      </section>
+
+      <section aria-labelledby="flows-heading">
+        <div className="mb-8 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 id="flows-heading" className="text-xl font-semibold text-white">
+              Three ways in
+            </h2>
+            <p className="mt-1 text-sm text-slate-500">Pick a flow — same data, different intent.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-5">
+          <FeatureCard
+            to="/plan"
+            title="Plan"
+            description="Timeline, price ribbon, and booking pressure in one calm surface."
+            icon={<Compass className="h-6 w-6" />}
+            accent="from-cyan-500/20 to-transparent"
           />
-          <Card
-            title="Price Trends"
-            description=""
+          <FeatureCard
+            to="/search"
+            title="Search"
+            description="Shop live offers with airports, dates, and trip type in a focused layout."
+            icon={<Plane className="h-6 w-6" />}
+            accent="from-violet-500/15 to-transparent"
+          />
+          <FeatureCard
             to="/trends"
+            title="Trends"
+            description="History and bands so you know if today’s fare is noise or signal."
+            icon={<LineChart className="h-6 w-6" />}
+            accent="from-amber-500/15 to-transparent"
+            className="sm:col-span-2 lg:col-span-1"
           />
         </div>
-      </div>
+      </section>
     </div>
   );
 }
 
-function Card({ title, description, to }: { title: string; description: string; to: string }) {
+function FeatureCard({
+  title,
+  description,
+  to,
+  icon,
+  accent,
+  className = '',
+}: {
+  title: string;
+  description: string;
+  to: string;
+  icon: ReactNode;
+  accent: string;
+  className?: string;
+}) {
   return (
-    <Link 
+    <Link
       to={to}
-      className="block p-6 bg-white rounded-lg border border-gray-200 shadow-md hover:shadow-lg transition-shadow"
+      className={`group relative overflow-hidden rounded-2xl border border-white/10 bg-slate-900/40 p-6 transition duration-300 hover:border-cyan-500/30 hover:bg-slate-900/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/60 ${className}`}
     >
-      <h2 className="mb-2 text-xl font-semibold text-gray-900">{title}</h2>
-      <p className="text-gray-600">{description}</p>
+      <div
+        className={`pointer-events-none absolute inset-0 bg-gradient-to-br opacity-60 transition group-hover:opacity-100 ${accent}`}
+        aria-hidden
+      />
+      <div className="relative flex h-11 w-11 items-center justify-center rounded-xl bg-white/5 text-cyan-300 ring-1 ring-white/10 transition group-hover:text-cyan-200">
+        {icon}
+      </div>
+      <h3 className="relative mt-5 text-lg font-semibold text-white">{title}</h3>
+      <p className="relative mt-2 text-sm leading-relaxed text-slate-400">{description}</p>
+      <span className="relative mt-4 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-cyan-400/80 group-hover:text-cyan-300">
+        Continue
+        <ArrowUpRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+      </span>
     </Link>
   );
 }

--- a/src/pages/PlanningPage.tsx
+++ b/src/pages/PlanningPage.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ArrowRight,
+  CalendarRange,
+  Compass,
+  Gauge,
+  Sparkles,
+  TrendingDown,
+} from 'lucide-react';
+import { getFlightPrices, type FlightPrice } from '../services/api';
+
+const SEGMENTS = [
+  { id: 'out', label: 'Outbound', from: 'JFK', to: 'LAX', stops: 'Nonstop' },
+  { id: 'rt', label: 'Return', from: 'LAX', to: 'JFK', stops: '1 stop · ORD 2h' },
+] as const;
+
+function heatLabel(price: number, min: number, max: number): { text: string; className: string } {
+  if (max <= min) return { text: 'Fair', className: 'bg-slate-600/35 text-slate-200 ring-1 ring-white/10' };
+  const t = (price - min) / (max - min);
+  if (t < 0.33) return { text: 'Low', className: 'bg-emerald-500/20 text-emerald-200 ring-1 ring-emerald-400/25' };
+  if (t < 0.66) return { text: 'Med', className: 'bg-amber-500/15 text-amber-100 ring-1 ring-amber-400/25' };
+  return { text: 'High', className: 'bg-rose-500/15 text-rose-100 ring-1 ring-rose-400/25' };
+}
+
+export default function PlanningPage() {
+  const [activeSeg, setActiveSeg] = useState<(typeof SEGMENTS)[number]['id']>('out');
+  const [prices, setPrices] = useState<FlightPrice[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [ms, setMs] = useState<number | null>(null);
+
+  const origin = 'JFK';
+  const dest = 'LAX';
+
+  const loadPrices = useCallback(async () => {
+    setLoading(true);
+    const t0 = performance.now();
+    try {
+      const p = await getFlightPrices(origin, dest, new Date().toISOString().slice(0, 10));
+      setPrices(p);
+      setMs(Math.round(performance.now() - t0));
+    } finally {
+      setLoading(false);
+    }
+  }, [origin, dest]);
+
+  const { minP, maxP } = useMemo(() => {
+    if (!prices?.length) return { minP: 0, maxP: 1 };
+    const vals = prices.map((x) => x.price);
+    return { minP: Math.min(...vals), maxP: Math.max(...vals) };
+  }, [prices]);
+
+  return (
+    <div className="min-h-screen bg-[hsl(var(--background))]">
+      <div className="relative overflow-hidden border-b border-[hsl(var(--border))]">
+        <div
+          className="pointer-events-none absolute inset-0 opacity-90"
+          style={{
+            background:
+              'linear-gradient(135deg, hsl(var(--primary) / 0.12) 0%, transparent 45%), linear-gradient(215deg, hsl(280 60% 96%) 0%, transparent 40%)',
+          }}
+        />
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 md:py-16">
+          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8">
+            <div>
+              <p className="inline-flex items-center gap-2 text-sm font-medium text-[hsl(var(--muted-foreground))] mb-3">
+                <Sparkles className="h-4 w-4 text-[hsl(var(--primary))]" aria-hidden />
+                Trip canvas
+              </p>
+              <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-[hsl(var(--foreground))]">
+                {origin} → {dest}
+              </h1>
+              <p className="mt-3 text-lg text-[hsl(var(--muted-foreground))] max-w-xl">
+                Scan windows, compare pressure, and move from watching to booking without losing context.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/search"
+                className="inline-flex items-center justify-center rounded-lg bg-[hsl(var(--primary))] px-5 py-2.5 text-sm font-semibold text-[hsl(var(--primary-foreground))] shadow-sm ring-offset-2 transition hover:opacity-95 focus:outline-none focus:ring-2 focus:ring-[hsl(var(--ring))]"
+              >
+                Search this route
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
+              </Link>
+              <Link
+                to="/trends"
+                className="inline-flex items-center justify-center rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))]/80 px-5 py-2.5 text-sm font-semibold text-[hsl(var(--foreground))] backdrop-blur-md transition hover:bg-[hsl(var(--card))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--ring))]"
+              >
+                Open trends
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-10">
+        {/* Route timeline */}
+        <section aria-labelledby="timeline-heading" className="space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <h2 id="timeline-heading" className="text-xl font-semibold text-[hsl(var(--foreground))]">
+              Route timeline
+            </h2>
+            <span className="text-sm text-[hsl(var(--muted-foreground))]">Tap a leg to focus price context</span>
+          </div>
+          <div
+            className="grid grid-cols-1 sm:grid-cols-2 gap-3"
+            role="tablist"
+            aria-label="Flight legs"
+          >
+            {SEGMENTS.map((s) => {
+              const active = activeSeg === s.id;
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => setActiveSeg(s.id)}
+                  className={`text-left rounded-xl border p-4 transition-all duration-200 ease-out focus:outline-none focus:ring-2 focus:ring-[hsl(var(--ring))] focus:ring-offset-2 ${
+                    active
+                      ? 'border-[hsl(var(--primary))] bg-[hsl(var(--card))] shadow-md shadow-[hsl(var(--primary)/0.12)]'
+                      : 'border-[hsl(var(--border))] bg-[hsl(var(--card))]/60 hover:border-[hsl(var(--primary)/0.35)]'
+                  }`}
+                >
+                  <p className="text-xs font-semibold uppercase tracking-wide text-[hsl(var(--muted-foreground))]">
+                    {s.label}
+                  </p>
+                  <p className="mt-1 text-lg font-semibold tabular-nums text-[hsl(var(--foreground))]">
+                    {s.from} → {s.to}
+                  </p>
+                  <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1">{s.stops}</p>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Price window heat ribbon */}
+        <section aria-labelledby="ribbon-heading" className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 id="ribbon-heading" className="text-xl font-semibold text-[hsl(var(--foreground))] flex items-center gap-2">
+              <CalendarRange className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden />
+              Price window
+            </h2>
+            <button
+              type="button"
+              onClick={loadPrices}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-lg bg-[hsl(var(--secondary))] px-4 py-2 text-sm font-medium text-[hsl(var(--secondary-foreground))] transition hover:bg-[hsl(var(--muted))] disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-[hsl(var(--ring))]"
+            >
+              {loading ? 'Loading…' : 'Refresh sample curve'}
+            </button>
+          </div>
+
+          <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))]/80 backdrop-blur-md p-4 md:p-6 shadow-sm">
+            {!prices && !loading && (
+              <p className="text-sm text-[hsl(var(--muted-foreground))]">
+                Load a quick price curve for this corridor (uses your configured API mode: Netlify, mock, or remote).
+              </p>
+            )}
+            {loading && (
+              <div className="h-16 flex items-center justify-center text-[hsl(var(--muted-foreground))] text-sm">
+                Fetching…
+              </div>
+            )}
+            {prices && prices.length > 0 && (
+              <div className="space-y-4">
+                <div className="flex flex-wrap gap-2" role="list">
+                  {prices.slice(0, 7).map((p, i) => {
+                    const d = p.date instanceof Date ? p.date : new Date(p.date);
+                    const { text, className } = heatLabel(p.price, minP, maxP);
+                    return (
+                      <div
+                        key={i}
+                        role="listitem"
+                        className={`flex min-w-[4.5rem] flex-col items-center rounded-lg px-2 py-2 text-center ${className}`}
+                      >
+                        <span className="text-[10px] font-medium uppercase text-[hsl(var(--muted-foreground))]">
+                          {d.toLocaleDateString(undefined, { weekday: 'short' })}
+                        </span>
+                        <span className="text-xs tabular-nums font-semibold">${p.price}</span>
+                        <span className="text-[10px] font-medium mt-0.5">{text}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+                {ms != null && (
+                  <p className="text-xs text-[hsl(var(--muted-foreground))] tabular-nums" aria-live="polite">
+                    Last request round-trip (client): {ms}ms
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* Commit vs watch + meter */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <section className="lg:col-span-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[hsl(var(--foreground))] mb-4 flex items-center gap-2">
+              <Compass className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden />
+              Commit vs watch
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border border-dashed border-[hsl(var(--border))] p-4 bg-[hsl(var(--muted))/0.35]">
+                <p className="text-xs font-semibold uppercase text-[hsl(var(--muted-foreground))]">Committed</p>
+                <p className="mt-2 text-sm text-[hsl(var(--foreground))]">Lock dates when the ribbon shows two consecutive “Low” days.</p>
+              </div>
+              <div className="rounded-xl border border-[hsl(var(--border))] p-4">
+                <p className="text-xs font-semibold uppercase text-[hsl(var(--muted-foreground))]">Watching</p>
+                <p className="mt-2 text-sm text-[hsl(var(--foreground))]">Flex ±3 days; we’ll nudge when the curve dips vs your baseline.</p>
+              </div>
+            </div>
+          </section>
+          <section className="rounded-2xl border border-[hsl(var(--border))] bg-gradient-to-br from-[hsl(var(--card))] to-[hsl(var(--muted))/0.4] p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[hsl(var(--foreground))] mb-4 flex items-center gap-2">
+              <Gauge className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden />
+              Booking pressure
+            </h2>
+            <div className="space-y-3">
+              <div className="h-2 rounded-full bg-[hsl(var(--muted))] overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-[hsl(var(--primary))] transition-all duration-500 ease-out"
+                  style={{ width: `${prices ? 62 : 35}%` }}
+                />
+              </div>
+              <p className="text-sm text-[hsl(var(--muted-foreground))] flex items-center gap-2">
+                <TrendingDown className="h-4 w-4 text-emerald-600" aria-hidden />
+                Favor booking soon if the next week trends “Med” or higher across the ribbon.
+              </p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PriceTrendsPage.tsx
+++ b/src/pages/PriceTrendsPage.tsx
@@ -302,26 +302,29 @@ export default function PriceTrendsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="min-h-screen px-4 py-8 sm:p-8">
       <div className="max-w-6xl mx-auto">
-        <div className="flex items-center mb-8">
-          <Link to="/" className="text-blue-600 hover:underline mr-4">
-            &larr; Back to Home
+        <div className="mb-8 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Price Trends</h1>
+            <p className="text-sm text-slate-500">History and bands for your corridor</p>
+          </div>
+          <Link to="/" className="text-sm font-medium text-cyan-400/90 hover:text-cyan-300">
+            ← Back home
           </Link>
-          <h1 className="text-2xl font-bold text-gray-900">Price Trends</h1>
         </div>
         
         {showLocationPrompt && (
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+          <div className="mb-6 rounded-xl border border-cyan-500/20 bg-slate-900/60 p-4 backdrop-blur-sm">
             <div className="flex items-start">
               <div className="flex-shrink-0">
-                <svg className="h-5 w-5 text-blue-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                <svg className="h-5 w-5 text-cyan-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
                 </svg>
               </div>
               <div className="ml-3 flex-1">
-                <h3 className="text-sm font-medium text-blue-800">Set your home airport</h3>
-                <p className="mt-1 text-sm text-blue-700">
+                <h3 className="text-sm font-medium text-cyan-200">Set your home airport</h3>
+                <p className="mt-1 text-sm text-slate-400">
                   {detectedAirport
                     ? `We detected you're near ${detectedAirport.name} (${detectedAirport.code}). Use this as your home airport?`
                     : 'Allow location access to find your nearest airport.'}
@@ -330,7 +333,7 @@ export default function PriceTrendsPage() {
                   {!detectedAirport && !isDetectingLocation && (
                     <button
                       onClick={requestLocation}
-                      className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 flex items-center"
+                      className="flex items-center rounded-md border border-transparent bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-500"
                     >
                       <svg className="h-4 w-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                         <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
@@ -339,7 +342,7 @@ export default function PriceTrendsPage() {
                     </button>
                   )}
                   {isDetectingLocation && (
-                    <div className="flex items-center text-sm text-blue-700">
+                    <div className="flex items-center text-sm text-slate-400">
                       <svg className="animate-spin h-4 w-4 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
@@ -351,13 +354,13 @@ export default function PriceTrendsPage() {
                     <>
                       <button
                         onClick={confirmDetectedAirport}
-                        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700"
+                        className="rounded-md border border-transparent bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-500"
                       >
                         Yes, use {detectedAirport.code}
                       </button>
                       <button
                         onClick={() => setDetectedAirport(null)}
-                        className="px-4 py-2 text-sm font-medium text-blue-700 bg-white border border-blue-300 rounded-md hover:bg-blue-100"
+                        className="rounded-md border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-slate-200 hover:bg-white/15"
                       >
                         Try again
                       </button>
@@ -367,7 +370,7 @@ export default function PriceTrendsPage() {
               </div>
               <button
                 onClick={dismissLocationPrompt}
-                className="ml-4 text-blue-400 hover:text-blue-600"
+                className="ml-4 text-slate-500 hover:text-cyan-400"
                 title="Skip and use default (JFK)"
               >
                 <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -378,7 +381,7 @@ export default function PriceTrendsPage() {
           </div>
         )}
 
-        <div className="bg-white p-6 rounded-lg shadow-md">
+        <div className="surface-paper p-6">
           <div className="mb-6">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
               {/* Origin Input with Autocomplete */}
@@ -391,7 +394,7 @@ export default function PriceTrendsPage() {
                   onChange={handleOriginInputChange}
                   onFocus={() => originInput.length >= 2 && setShowOriginSuggestions(true)}
                   placeholder="City or IATA code (e.g., JFK, NYC)"
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500 text-sm"
                 />
                 {showOriginSuggestions && originSuggestions.length > 0 && (
                   <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto">
@@ -423,7 +426,7 @@ export default function PriceTrendsPage() {
                   onChange={handleDestinationInputChange}
                   onFocus={() => destinationInput.length >= 2 && setShowDestinationSuggestions(true)}
                   placeholder="City or IATA code (e.g., LHR, London)"
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500 text-sm"
                 />
                 {showDestinationSuggestions && destinationSuggestions.length > 0 && (
                   <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto">
@@ -452,7 +455,7 @@ export default function PriceTrendsPage() {
                   id="stops"
                   value={stopsFilter}
                   onChange={(e) => setStopsFilter(e.target.value as StopsFilter)}
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500 text-sm"
                 >
                   <option value="cheapest">Cheapest</option>
                   <option value="0">Nonstop</option>
@@ -468,8 +471,8 @@ export default function PriceTrendsPage() {
                   onClick={handleUpdate}
                   disabled={isLoading || isSearching}
                   className={`w-full inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white ${
-                    isLoading || isSearching ? 'bg-blue-400' : 'bg-blue-600 hover:bg-blue-700'
-                  } focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
+                    isLoading || isSearching ? 'bg-cyan-400' : 'bg-cyan-600 hover:bg-cyan-500'
+                  } focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500`}
                 >
                   {isLoading ? 'Loading...' : 'Update Chart'}
                 </button>
@@ -485,7 +488,7 @@ export default function PriceTrendsPage() {
                       onClick={() => handleTabChange(index)}
                       className={`py-4 px-6 text-center border-b-2 font-medium text-sm ${
                         tabValue === index
-                          ? 'border-blue-500 text-blue-600'
+                          ? 'border-cyan-500 text-cyan-600'
                           : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
                       }`}
                       id={`${type}-tab`}
@@ -508,7 +511,7 @@ export default function PriceTrendsPage() {
                   <div className="h-96">
                     {isLoading ? (
                       <div className="flex items-center justify-center h-full">
-                        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+                        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-cyan-500"></div>
                       </div>
                     ) : error ? (
                       <div className="bg-red-50 border-l-4 border-red-400 p-4">

--- a/src/pages/SearchFlightsPage.tsx
+++ b/src/pages/SearchFlightsPage.tsx
@@ -266,29 +266,32 @@ export default function SearchFlightsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="min-h-screen px-4 py-8 sm:p-8">
       <div className="max-w-6xl mx-auto">
-        <div className="flex items-center mb-8">
-          <Link to="/" className="text-blue-600 hover:underline mr-4">
-            &larr; Back to Home
+        <div className="mb-8 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Search Flights</h1>
+            <p className="text-sm text-slate-500">Shop offers for your dates and route</p>
+          </div>
+          <Link to="/" className="text-sm font-medium text-cyan-400/90 hover:text-cyan-300">
+            ← Back home
           </Link>
-          <h1 className="text-2xl font-bold text-gray-900">Search Flights</h1>
         </div>
 
-        <div className="bg-white p-6 rounded-lg shadow-md mb-8">
+        <div className="surface-paper p-6 mb-8">
           <form onSubmit={handleSearch}>
             {/* Trip Type Toggle */}
             <div className="flex space-x-2 mb-6">
               <button
                 type="button"
-                className={`px-4 py-2 rounded-l-lg text-sm font-medium ${tripType === 'one-way' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'}`}
+                className={`px-4 py-2 rounded-l-lg text-sm font-medium ${tripType === 'one-way' ? 'bg-cyan-600 text-white' : 'bg-slate-100 text-slate-700'}`}
                 onClick={() => setTripType('one-way')}
               >
                 One Way
               </button>
               <button
                 type="button"
-                className={`px-4 py-2 rounded-r-lg text-sm font-medium ${tripType === 'round-trip' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700'}`}
+                className={`px-4 py-2 rounded-r-lg text-sm font-medium ${tripType === 'round-trip' ? 'bg-cyan-600 text-white' : 'bg-slate-100 text-slate-700'}`}
                 onClick={() => setTripType('round-trip')}
               >
                 Round Trip
@@ -306,7 +309,7 @@ export default function SearchFlightsPage() {
                   onChange={handleOriginInputChange}
                   onFocus={() => originInput.length >= 2 && setShowOriginSuggestions(true)}
                   placeholder="City or IATA code (e.g., JFK, NYC)"
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500 text-sm"
                 />
                 {showOriginSuggestions && originSuggestions.length > 0 && (
                   <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto">
@@ -338,7 +341,7 @@ export default function SearchFlightsPage() {
                   onChange={handleDestinationInputChange}
                   onFocus={() => destinationInput.length >= 2 && setShowDestinationSuggestions(true)}
                   placeholder="City or IATA code (e.g., LHR, London)"
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500 text-sm"
                 />
                 {showDestinationSuggestions && destinationSuggestions.length > 0 && (
                   <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto">
@@ -366,7 +369,7 @@ export default function SearchFlightsPage() {
                 <input
                   type="date"
                   id="departureDate"
-                  className="w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                  className="w-full rounded-lg border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
                   required
                   value={departureDate}
                   onChange={(e) => setDepartureDate(e.target.value)}
@@ -381,7 +384,7 @@ export default function SearchFlightsPage() {
                   <input
                     type="date"
                     id="returnDate"
-                    className="w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                    className="w-full rounded-lg border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
                     required={tripType === 'round-trip'}
                     value={returnDate}
                     onChange={(e) => setReturnDate(e.target.value)}
@@ -397,8 +400,8 @@ export default function SearchFlightsPage() {
                 type="submit"
                 disabled={isSearching || isLoadingAirports}
                 className={`w-full inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white ${
-                  isSearching || isLoadingAirports ? 'bg-blue-400' : 'bg-blue-600 hover:bg-blue-700'
-                } focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
+                  isSearching || isLoadingAirports ? 'bg-cyan-400' : 'bg-cyan-600 hover:bg-cyan-500'
+                } focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500`}
               >
                 {isSearching ? (
                   <span className="flex items-center justify-center">
@@ -449,7 +452,7 @@ export default function SearchFlightsPage() {
             
             {isSearching ? (
               <div className="flex items-center justify-center p-8">
-                <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+                <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-cyan-500"></div>
               </div>
             ) : flights.length > 0 ? (
               <div className="space-y-4">
@@ -517,7 +520,7 @@ export default function SearchFlightsPage() {
                             href={getBookingLink(flight)}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors flex items-center"
+                            className="flex items-center rounded-lg bg-cyan-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-cyan-500"
                           >
                             Book Flight
                             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-1" viewBox="0 0 20 20" fill="currentColor">

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -1,10 +1,45 @@
-import axios from 'axios';
+jest.mock('../../config/runtime', () => ({
+  getApiMode: () => 'netlify' as const,
+  getApiBaseUrl: () => '/.netlify/functions',
+  getApiTimeoutMs: () => 20000,
+  mockRoutesFromEnv: () => false,
+}));
+
+const mockGet = jest.fn();
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: () => ({
+      get: mockGet,
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
+      },
+    }),
+  },
+}));
+
 import * as api from '../api';
 const { getFlightPrices, getRoutes, generateMockPrices, generateMockRoutes } = api;
 
-// Mock axios
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('../routeService', () => ({
+  hasRoutes: jest.fn().mockResolvedValue(true),
+  saveApiRoutes: jest.fn().mockResolvedValue(undefined),
+  getRoutes: jest.fn().mockResolvedValue([
+    {
+      id: 1,
+      origin: 'JFK',
+      destination: 'LAX',
+      price: 299,
+      departure_date: new Date('2025-06-01'),
+      return_date: null,
+      airline: 'AA',
+      flight_number: 'AA100',
+      created_at: new Date(),
+      updated_at: new Date(),
+    },
+  ]),
+}));
 
 describe('API Service', () => {
   beforeEach(() => {
@@ -12,113 +47,63 @@ describe('API Service', () => {
   });
 
   describe('getFlightPrices', () => {
-    it('should fetch flight prices from Duffel API', async () => {
-      // Mock successful API response
-      const mockResponse = {
+    it('should fetch flight prices via Netlify function (GET)', async () => {
+      mockGet.mockResolvedValueOnce({
         data: {
-          data: {
-            offers: [
-              { amount: 300, created_at: '2025-05-18' },
-              { amount: 350, created_at: '2025-05-19' },
-            ]
-          }
-        }
-      };
-      
-      mockedAxios.post.mockResolvedValueOnce(mockResponse);
-      
+          prices: [
+            { date: '2025-05-18', price: 300 },
+            { date: '2025-05-19', price: 350 },
+          ],
+          source: 'amadeus',
+        },
+      });
+
       const result = await getFlightPrices('JFK', 'LHR', '2025-05-18');
-      
-      // Check that API was called with correct parameters
-      expect(mockedAxios.post).toHaveBeenCalledWith(
-        '/offer_requests',
-        expect.objectContaining({
-          data: expect.objectContaining({
-            slices: expect.arrayContaining([
-              expect.objectContaining({
-                origin: 'JFK',
-                destination: 'LHR'
-              })
-            ])
-          })
-        })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        '/flight-prices?from=JFK&to=LHR',
+        expect.objectContaining({ signal: undefined })
       );
-      
-      // Check that result is formatted correctly
       expect(result).toHaveLength(2);
       expect(result[0]).toHaveProperty('price', 300);
-      expect(result[0]).toHaveProperty('date');
+      expect(result[0].date).toBeInstanceOf(Date);
     });
-    
+
     it('should return mock prices when API call fails', async () => {
-      // Mock failed API response
-      mockedAxios.post.mockRejectedValueOnce(new Error('API Error'));
-      
+      mockGet.mockRejectedValueOnce(new Error('API Error'));
+
       const result = await getFlightPrices('JFK', 'LHR', '2025-05-18');
-      
-      // Check that mock data was returned
-      expect(result).toHaveLength(expect.any(Number));
+
+      expect(result.length).toBe(7);
       expect(result[0]).toHaveProperty('price');
       expect(result[0]).toHaveProperty('date');
     });
   });
-  
+
   describe('getRoutes', () => {
-    it('should fetch popular routes with prices', async () => {
-      // Mock successful API response for each route
-      const mockPrices = [
-        { price: 300, date: '2025-05-18' },
-        { price: 350, date: '2025-05-19' },
-      ];
-      
-      // Spy on getFlightPrices to return mock prices
-      jest.spyOn(api, 'getFlightPrices').mockResolvedValue(mockPrices as any);
-      
+    it('should return routes from Postgres via routeService', async () => {
       const result = await getRoutes();
-      
-      // Check that routes are returned with prices
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0]).toHaveProperty('from');
-      expect(result[0]).toHaveProperty('to');
-      expect(result[0]).toHaveProperty('prices', mockPrices);
-    });
-    
-    it('should return mock routes when API call fails', async () => {
-      // Mock failed API response
-      jest.spyOn(api, 'getFlightPrices').mockRejectedValue(new Error('API Error'));
-      
-      const result = await getRoutes();
-      
-      // Check that mock routes were returned
       expect(result.length).toBeGreaterThan(0);
       expect(result[0]).toHaveProperty('from');
       expect(result[0]).toHaveProperty('to');
       expect(result[0]).toHaveProperty('prices');
     });
   });
-  
+
   describe('Mock Data Generation', () => {
     it('should generate realistic mock prices', () => {
       const mockPrices = generateMockPrices();
-      
-      // Check that mock prices are generated with correct properties
       expect(mockPrices.length).toBeGreaterThan(0);
       expect(mockPrices[0]).toHaveProperty('price');
       expect(mockPrices[0]).toHaveProperty('date');
-      
-      // Check that prices follow expected patterns
       const prices = mockPrices.map((p: { price: number }) => p.price);
       const minPrice = Math.min(...prices);
       const maxPrice = Math.max(...prices);
-      
-      // Ensure there's some variation in prices
       expect(maxPrice - minPrice).toBeGreaterThan(50);
     });
-    
+
     it('should generate mock routes with prices', () => {
       const mockRoutes = generateMockRoutes();
-      
-      // Check that mock routes are generated with correct properties
       expect(mockRoutes.length).toBeGreaterThan(0);
       expect(mockRoutes[0]).toHaveProperty('id');
       expect(mockRoutes[0]).toHaveProperty('from');

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getApiBaseUrl, getApiMode, getApiTimeoutMs, mockRoutesFromEnv } from '../config/runtime';
 import { saveRoute as saveDbRoute, DbRoute } from './routeService';
 
 // Interface for flight details
@@ -30,21 +31,37 @@ export interface RouteMeta {
   _error?: string;
 }
 
-// API configuration
-// Use relative path in both development and production
-// This ensures functions are called on the same domain as the frontend
-// Netlify Dev runs on port 3000 and handles function proxying in development
-// In production, the frontend and functions are on the same Netlify deployment
-const API_BASE_URL = '/.netlify/functions';
-
-// Create axios instance with default configuration
-export const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json'
+// API configuration: same-origin `/.netlify/functions` by default; override with VITE_API_URL / VITE_REMOTE_API_BASE
+const createApiClient = () => {
+  const client = axios.create({
+    baseURL: getApiBaseUrl(),
+    timeout: getApiTimeoutMs(),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  });
+  if (process.env.NODE_ENV === 'development') {
+    client.interceptors.request.use((config) => {
+      (config as { metadata?: { t: number } }).metadata = { t: performance.now() };
+      return config;
+    });
+    client.interceptors.response.use(
+      (res) => {
+        const meta = (res.config as { metadata?: { t: number } }).metadata;
+        if (meta?.t != null) {
+          const ms = Math.round(performance.now() - meta.t);
+          console.debug(`[api] ${res.config.baseURL ?? ''}${res.config.url ?? ''} ${ms}ms`);
+        }
+        return res;
+      },
+      (err) => Promise.reject(err)
+    );
   }
-});
+  return client;
+};
+
+export const apiClient = createApiClient();
 
 // Interface for API route
 export interface ApiRoute {
@@ -194,9 +211,28 @@ interface PriceHistoryResponse {
   source: string;
 }
 
-export async function getPriceHistory(from: string, to: string): Promise<PriceHistoryResponse> {
+export async function getPriceHistory(
+  from: string,
+  to: string,
+  options?: { signal?: AbortSignal }
+): Promise<PriceHistoryResponse> {
+  if (getApiMode() === 'mock') {
+    const mockPrices = generateMockPrices();
+    return {
+      prices: mockPrices.map((p) => ({
+        date: typeof p.date === 'string' ? p.date : p.date.toISOString().split('T')[0],
+        price: p.price,
+      })),
+      basePrice: 300,
+      lowestPrice: Math.min(...mockPrices.map((p) => p.price)),
+      highestPrice: Math.max(...mockPrices.map((p) => p.price)),
+      source: 'mock',
+    };
+  }
   try {
-    const response = await apiClient.get<PriceHistoryResponse>(`/flight-prices?from=${from}&to=${to}`);
+    const response = await apiClient.get<PriceHistoryResponse>(`/flight-prices?from=${from}&to=${to}`, {
+      signal: options?.signal,
+    });
     // Ensure the response has the correct format
     if (response.data && Array.isArray(response.data.prices)) {
       return {
@@ -228,12 +264,23 @@ export async function getPriceHistory(from: string, to: string): Promise<PriceHi
 }
 
 // Get flight prices for a route over time
-export const getFlightPrices = async (from: string, to: string, departDate: string): Promise<FlightPrice[]> => {
+export const getFlightPrices = async (
+  from: string,
+  to: string,
+  departDate: string,
+  options?: { signal?: AbortSignal }
+): Promise<FlightPrice[]> => {
+  if (getApiMode() === 'mock') {
+    const routeHash = from.charCodeAt(0) + to.charCodeAt(0);
+    const basePrice = 400 + (routeHash % 500);
+    return generateMockPrices(basePrice);
+  }
   try {
     console.log(`Fetching prices from ${from} to ${to} for ${departDate}`);
-    
-    // Call our Netlify function to get flight prices
-    const response = await apiClient.get(`/flight-prices?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`);
+
+    const response = await apiClient.get(`/flight-prices?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`, {
+      signal: options?.signal,
+    });
     
     if (response.data && response.data.prices) {
       console.log(`Received ${response.data.prices.length} prices from ${response.data.source} source`);
@@ -420,6 +467,13 @@ export const loadDefaultRoutes = async (): Promise<void> => {
 
 // Get available routes with database fallback
 export const getRoutes = async (): Promise<ApiRoute[]> => {
+  if (mockRoutesFromEnv()) {
+    return generateFallbackRoutes().map((route, index) => ({
+      ...route,
+      id: `mock-${index + 1}`,
+      meta: { ...route.meta, source: 'mock-local' },
+    }));
+  }
   try {
     console.log('1. Loading default routes if needed...');
     await loadDefaultRoutes();
@@ -476,7 +530,5 @@ export const getRoutes = async (): Promise<ApiRoute[]> => {
     // Return empty array on error
     console.warn('11. Error occurred, returning empty array');
     return [];
-  } finally {
-    console.groupEnd();
   }
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_MODE?: 'netlify' | 'mock' | 'remote';
+  /** Same-origin path (default `/.netlify/functions`) or full URL for remote mocks */
+  readonly VITE_API_URL?: string;
+  readonly VITE_API_BASE_URL?: string;
+  /** When `VITE_API_MODE=remote`, full base including path prefix to functions */
+  readonly VITE_REMOTE_API_BASE?: string;
+  readonly VITE_API_TIMEOUT_MS?: string;
+  /** Skip Postgres-backed getRoutes and use seeded routes (fast UI/dev) */
+  readonly VITE_USE_MOCK_ROUTES?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,9 @@ module.exports = {
         "2xl": "1400px",
       },
     },
+    fontFamily: {
+      sans: ['"Plus Jakarta Sans"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+    },
     extend: {
       colors: {
         border: "hsl(var(--border))",


### PR DESCRIPTION
## Summary

This pull request replaces the generic gray/blue shell with a cohesive **horizon** visual system (dark atmospheric background, glass header, Plus Jakarta Sans, cyan primary actions) and adds a **Plan** experience plus clearer API configuration for local and remote testing.

## UI

- New **home**: hero copy, primary/secondary CTAs, and bento-style feature cards for Plan, Search, and Trends.
- **App shell**: sticky blurred header, `NavLink` pill states, mobile nav row, short footer.
- **Search / Trends**: `surface-paper` panels on the dark shell; page titles and links readable on the background; cyan replaces generic blue for primary controls where updated.
- **Planning** (`/plan`): trip canvas, price window ribbon, commit vs watch, pressure meter (lazy-loaded chunk + prefetch on nav hover).

## API and backend

- Client **runtime** (`src/config/runtime.ts`): `VITE_API_MODE` (netlify | mock | remote), base URL, timeout, optional instant mock routes.
- **Axios**: configurable base URL and timeout; dev timing logs; optional `AbortSignal` on price calls.
- **Netlify**: shared `getFlightPricesForDates` in `netlify/functions/lib/amadeusBatch.js`; **popular-routes** now calls it correctly; **flight-prices** supports `USE_MOCK_DATA` / `AMADEUS_MOCK` and fixes mock fallback logging.

## CI and developer workflow

- **deploy-gamma** job: deploys when `deployment-config.json` targets `gamma`, using `secrets.NETLIFY_SITE_ID_GAMMA` and existing `NETLIFY_AUTH_TOKEN`. Manual dispatch includes **gamma**.
- **.env.example**, `scripts/test-local-functions.mjs`, and `npm run test:functions-local` for local smoke tests without a full Netlify deploy.

## Tests

- Jest config uses `module.exports`; `api` and `RouteCard` tests aligned with current behavior.

## Checklist for reviewers

- [ ] Confirm `NETLIFY_SITE_ID_GAMMA` is set in repo secrets if gamma deploys should run.
- [ ] Optional: run `npm run build`, `npm test`, and `npm run dev` locally.

Made with [Cursor](https://cursor.com)