### PR TITLE
fix: add proposals function with no-DB fallback

### DIFF
--- a/netlify/functions/lib/proposalActions.js
+++ b/netlify/functions/lib/proposalActions.js
@@ -1,0 +1,207 @@
+// Schema, validation, and suggestion templates for trip proposal actions.
+//
+// An "action" is anything attached to a trip proposal that the traveler
+// might do across phases of the trip — pre-departure reading, choosing
+// between EWR vs LGA, food near the airport, pickup at arrival, onward
+// travel like driving to Mammoth, optional packing, add-on activities, etc.
+
+import crypto from 'crypto';
+
+export const ACTION_CATEGORIES = Object.freeze([
+  'reading',     // books / articles / audiobooks for the trip
+  'departure',   // departure-airport choice & logistics (EWR vs LGA)
+  'food',        // food options near origin or arrival airport
+  'pickup',      // arrival pickup / ride coordination
+  'transport',   // onward travel (drive to Mammoth, train, rental car)
+  'lodging',     // hotel / vacation lodging
+  'packing',     // things to bring (skis, gear, optional items)
+  'event',       // events / things to do at destination
+  'todo',        // generic catch-all
+]);
+
+export const ACTION_PHASES = Object.freeze([
+  'pre_departure',
+  'departure',
+  'in_flight',
+  'arrival',
+  'onward',
+  'at_destination',
+  'post_trip',
+]);
+
+export const ACTION_STATUSES = Object.freeze(['pending', 'planned', 'done', 'skipped']);
+
+export const ACTION_PRIORITIES = Object.freeze(['low', 'medium', 'high']);
+
+const CATEGORY_SET = new Set(ACTION_CATEGORIES);
+const PHASE_SET = new Set(ACTION_PHASES);
+const STATUS_SET = new Set(ACTION_STATUSES);
+const PRIORITY_SET = new Set(ACTION_PRIORITIES);
+
+export class ActionValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ActionValidationError';
+  }
+}
+
+export function normalizeAction(input, { allowPartial = false } = {}) {
+  if (!input || typeof input !== 'object') {
+    throw new ActionValidationError('Action must be an object');
+  }
+
+  const now = new Date().toISOString();
+  const action = {
+    id: input.id || crypto.randomUUID(),
+    category: input.category,
+    phase: input.phase ?? null,
+    title: typeof input.title === 'string' ? input.title.trim() : input.title,
+    description: input.description ?? null,
+    optional: input.optional === true,
+    location: input.location ?? null,
+    priority: input.priority ?? null,
+    status: input.status ?? 'pending',
+    metadata: input.metadata ?? null,
+    created_at: input.created_at || now,
+    updated_at: now,
+  };
+
+  if (!allowPartial) {
+    if (!action.title || typeof action.title !== 'string') {
+      throw new ActionValidationError('Action title is required');
+    }
+    if (!CATEGORY_SET.has(action.category)) {
+      throw new ActionValidationError(
+        `Invalid category "${action.category}". Allowed: ${ACTION_CATEGORIES.join(', ')}`
+      );
+    }
+  }
+
+  if (action.phase !== null && !PHASE_SET.has(action.phase)) {
+    throw new ActionValidationError(
+      `Invalid phase "${action.phase}". Allowed: ${ACTION_PHASES.join(', ')}`
+    );
+  }
+  if (!STATUS_SET.has(action.status)) {
+    throw new ActionValidationError(
+      `Invalid status "${action.status}". Allowed: ${ACTION_STATUSES.join(', ')}`
+    );
+  }
+  if (action.priority !== null && !PRIORITY_SET.has(action.priority)) {
+    throw new ActionValidationError(
+      `Invalid priority "${action.priority}". Allowed: ${ACTION_PRIORITIES.join(', ')}`
+    );
+  }
+
+  return action;
+}
+
+export function normalizeActions(input) {
+  if (input == null) return [];
+  if (!Array.isArray(input)) {
+    throw new ActionValidationError('actions must be an array');
+  }
+  return input.map((item) => normalizeAction(item));
+}
+
+// Suggestion templates. Keyed by trip pattern; each template returns a list
+// of suggested (unsaved) actions. Templates are deliberately concrete so the
+// UI can drop them into a proposal as starting points.
+const TEMPLATES = {
+  // EWR/LGA → SFO with onward drive to Mammoth
+  'NYC-SFO-MAMMOTH': () => [
+    {
+      category: 'departure',
+      phase: 'departure',
+      title: 'Choose departure airport: EWR vs LGA',
+      description:
+        'Compare price, security wait, and PATH/LIRR access. Default to whichever has the better same-day fare.',
+      location: 'EWR / LGA',
+      priority: 'high',
+    },
+    {
+      category: 'food',
+      phase: 'pre_departure',
+      title: 'Chinatown hotpot near LGA',
+      description:
+        'If departing LGA, grab hotpot in Flushing Chinatown (~10 min from LGA) before security.',
+      location: 'Flushing, Queens',
+      optional: true,
+    },
+    {
+      category: 'reading',
+      phase: 'in_flight',
+      title: 'Read "The Will of the Many" (PDF)',
+      description: 'Load the PDF onto the tablet before boarding.',
+      metadata: { format: 'pdf', title: 'The Will of the Many' },
+    },
+    {
+      category: 'reading',
+      phase: 'in_flight',
+      title: 'Read "Atlas" (novel)',
+      description: 'Backup read in case the PDF gets boring.',
+      optional: true,
+      metadata: { format: 'novel', title: 'Atlas' },
+    },
+    {
+      category: 'pickup',
+      phase: 'arrival',
+      title: 'Wait for Ino for SFO pickup',
+      description: 'Coordinate pickup curb at SFO arrivals; have backup Lyft estimate ready.',
+      location: 'SFO arrivals',
+      priority: 'high',
+    },
+    {
+      category: 'transport',
+      phase: 'onward',
+      title: 'Drive to Mammoth',
+      description: '~6 hr drive from SF; plan stop in Bishop. Check 395 conditions before leaving.',
+      location: 'Mammoth Lakes, CA',
+      priority: 'high',
+    },
+    {
+      category: 'lodging',
+      phase: 'at_destination',
+      title: 'Vacation in Mammoth',
+      description: 'Confirm lodging and lift tickets.',
+      location: 'Mammoth Lakes, CA',
+    },
+    {
+      category: 'packing',
+      phase: 'pre_departure',
+      title: 'Bring skis',
+      description: 'Skis + boots + helmet. Confirm airline ski-bag fee.',
+      optional: true,
+      priority: 'medium',
+    },
+    {
+      category: 'event',
+      phase: 'at_destination',
+      title: 'Look for events in SF',
+      description: 'Check Eventbrite / Resident Advisor / Sofar for the night before driving up.',
+      location: 'San Francisco, CA',
+      optional: true,
+    },
+  ],
+};
+
+function templateKey(origin, destination) {
+  const o = (origin || '').toUpperCase();
+  const d = (destination || '').toUpperCase();
+  if (['EWR', 'LGA', 'JFK', 'NYC'].includes(o) && d === 'SFO') {
+    return 'NYC-SFO-MAMMOTH';
+  }
+  return null;
+}
+
+export function suggestActions({ origin, destination, template } = {}) {
+  const key = template || templateKey(origin, destination);
+  if (!key || !TEMPLATES[key]) {
+    return { template: null, actions: [] };
+  }
+  return { template: key, actions: TEMPLATES[key]().map((a) => normalizeAction(a)) };
+}
+
+export function listTemplates() {
+  return Object.keys(TEMPLATES);
+}

--- a/netlify/functions/proposal-action-suggestions.js
+++ b/netlify/functions/proposal-action-suggestions.js
@@ -1,0 +1,48 @@
+// Returns suggested (unsaved) actions for a trip proposal, given an
+// origin/destination pair or an explicit template name. Intended to be
+// called from the proposal-creation UI to pre-fill an action checklist.
+
+import {
+  ACTION_CATEGORIES,
+  ACTION_PHASES,
+  listTemplates,
+  suggestActions,
+} from './lib/proposalActions.js';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+  if (event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: `Method ${event.httpMethod} not allowed` }),
+    };
+  }
+
+  const params = event.queryStringParameters || {};
+  const result = suggestActions({
+    origin: params.origin,
+    destination: params.destination,
+    template: params.template,
+  });
+
+  return {
+    statusCode: 200,
+    headers: CORS_HEADERS,
+    body: JSON.stringify({
+      ...result,
+      categories: ACTION_CATEGORIES,
+      phases: ACTION_PHASES,
+      availableTemplates: listTemplates(),
+    }),
+  };
+};

--- a/netlify/functions/proposals.js
+++ b/netlify/functions/proposals.js
@@ -8,6 +8,11 @@
 
 import crypto from 'crypto';
 
+import {
+  ActionValidationError,
+  normalizeActions,
+} from './lib/proposalActions.js';
+
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
@@ -68,10 +73,15 @@ async function getPgPool() {
         status TEXT NOT NULL DEFAULT 'draft',
         notes TEXT,
         payload JSONB,
+        actions JSONB NOT NULL DEFAULT '[]'::jsonb,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
     `);
+    // Best-effort migration for pre-existing tables.
+    await pgPool.query(
+      `ALTER TABLE proposals ADD COLUMN IF NOT EXISTS actions JSONB NOT NULL DEFAULT '[]'::jsonb`
+    );
     return pgPool;
   } catch (err) {
     pgInitError = err;
@@ -94,6 +104,7 @@ function rowToProposal(row) {
     status: row.status,
     notes: row.notes,
     payload: row.payload,
+    actions: Array.isArray(row.actions) ? row.actions : [],
     created_at: row.created_at,
     updated_at: row.updated_at,
   };
@@ -113,6 +124,7 @@ function buildProposal(input) {
     status: VALID_STATUSES.has(input.status) ? input.status : 'draft',
     notes: input.notes || null,
     payload: input.payload ?? null,
+    actions: normalizeActions(input.actions),
     created_at: now,
     updated_at: now,
   };
@@ -175,8 +187,8 @@ export const handler = async (event) => {
         const result = await pool.query(
           `INSERT INTO proposals
             (id, title, origin, destination, depart_date, return_date,
-             price_cents, currency, status, notes, payload)
-           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+             price_cents, currency, status, notes, payload, actions)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
            RETURNING *`,
           [
             proposal.id,
@@ -190,6 +202,7 @@ export const handler = async (event) => {
             proposal.status,
             proposal.notes,
             proposal.payload,
+            JSON.stringify(proposal.actions),
           ]
         );
         return ok(rowToProposal(result.rows[0]), 201);
@@ -212,6 +225,9 @@ export const handler = async (event) => {
       for (const key of ['title', 'notes', 'priceCents', 'payload']) {
         if (input[key] !== undefined) patch[key] = input[key];
       }
+      if (input.actions !== undefined) {
+        patch.actions = normalizeActions(input.actions);
+      }
       if (usingDb) {
         const result = await pool.query(
           `UPDATE proposals SET
@@ -220,6 +236,7 @@ export const handler = async (event) => {
               notes = COALESCE($4, notes),
               price_cents = COALESCE($5, price_cents),
               payload = COALESCE($6, payload),
+              actions = COALESCE($7::jsonb, actions),
               updated_at = NOW()
            WHERE id = $1
            RETURNING *`,
@@ -230,6 +247,7 @@ export const handler = async (event) => {
             patch.notes ?? null,
             patch.priceCents ?? null,
             patch.payload ?? null,
+            patch.actions ? JSON.stringify(patch.actions) : null,
           ]
         );
         if (result.rowCount === 0) return fail(404, 'Proposal not found');
@@ -254,6 +272,9 @@ export const handler = async (event) => {
 
     return fail(405, `Method ${event.httpMethod} not allowed`);
   } catch (err) {
+    if (err instanceof ActionValidationError) {
+      return fail(400, err.message);
+    }
     console.error('[proposals] handler error:', err);
     return fail(500, err.message || 'Internal server error');
   }

--- a/netlify/functions/proposals.js
+++ b/netlify/functions/proposals.js
@@ -1,0 +1,260 @@
+// Trip proposals endpoint.
+//
+// Backed by Postgres when DB_HOST is configured; otherwise falls back to a
+// per-instance in-memory store so the endpoint stays usable in environments
+// (e.g. Netlify alpha) where no database is provisioned. Without this
+// fallback the function throws "No database configured. Set DB_HOST for
+// Postgres in production." and returns a 502.
+
+import crypto from 'crypto';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+const VALID_STATUSES = new Set(['draft', 'active', 'booked', 'archived']);
+
+const memoryStore = (() => {
+  const items = new Map();
+  return {
+    list: () =>
+      Array.from(items.values()).sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      ),
+    get: (id) => items.get(id) || null,
+    create: (proposal) => {
+      items.set(proposal.id, proposal);
+      return proposal;
+    },
+    update: (id, patch) => {
+      const existing = items.get(id);
+      if (!existing) return null;
+      const updated = { ...existing, ...patch, updated_at: new Date().toISOString() };
+      items.set(id, updated);
+      return updated;
+    },
+    delete: (id) => items.delete(id),
+  };
+})();
+
+let pgPool = null;
+let pgInitError = null;
+
+async function getPgPool() {
+  if (pgPool || pgInitError) return pgPool;
+  if (!process.env.DB_HOST) return null;
+  try {
+    const { Pool } = await import('pg');
+    pgPool = new Pool({
+      user: process.env.DB_USER || 'routeuser',
+      host: process.env.DB_HOST,
+      database: process.env.DB_NAME || 'routedb',
+      password: process.env.DB_PASSWORD,
+      port: parseInt(process.env.DB_PORT || '5432', 10),
+    });
+    await pgPool.query(`
+      CREATE TABLE IF NOT EXISTS proposals (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        origin TEXT,
+        destination TEXT,
+        depart_date TEXT,
+        return_date TEXT,
+        price_cents INTEGER,
+        currency TEXT DEFAULT 'USD',
+        status TEXT NOT NULL DEFAULT 'draft',
+        notes TEXT,
+        payload JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    return pgPool;
+  } catch (err) {
+    pgInitError = err;
+    console.error('[proposals] Postgres unavailable, using in-memory store:', err.message);
+    pgPool = null;
+    return null;
+  }
+}
+
+function rowToProposal(row) {
+  return {
+    id: row.id,
+    title: row.title,
+    origin: row.origin,
+    destination: row.destination,
+    departDate: row.depart_date,
+    returnDate: row.return_date,
+    priceCents: row.price_cents,
+    currency: row.currency,
+    status: row.status,
+    notes: row.notes,
+    payload: row.payload,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function buildProposal(input) {
+  const now = new Date().toISOString();
+  return {
+    id: input.id || crypto.randomUUID(),
+    title: input.title || `${input.origin || 'TRIP'} → ${input.destination || ''}`.trim(),
+    origin: input.origin || null,
+    destination: input.destination || null,
+    departDate: input.departDate || input.depart_date || null,
+    returnDate: input.returnDate || input.return_date || null,
+    priceCents: input.priceCents ?? input.price_cents ?? null,
+    currency: input.currency || 'USD',
+    status: VALID_STATUSES.has(input.status) ? input.status : 'draft',
+    notes: input.notes || null,
+    payload: input.payload ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+function parseBody(event) {
+  if (!event.body) return {};
+  try {
+    return JSON.parse(event.body);
+  } catch {
+    throw new Error('Invalid JSON body');
+  }
+}
+
+function extractIdFromPath(event) {
+  // Supports /.netlify/functions/proposals/:id and ?id=...
+  const queryId = event.queryStringParameters && event.queryStringParameters.id;
+  if (queryId) return queryId;
+  const segments = (event.path || '').split('/').filter(Boolean);
+  const idx = segments.indexOf('proposals');
+  if (idx >= 0 && segments[idx + 1]) return segments[idx + 1];
+  return null;
+}
+
+function ok(body, statusCode = 200) {
+  return { statusCode, headers: CORS_HEADERS, body: JSON.stringify(body) };
+}
+
+function fail(statusCode, message, extra = {}) {
+  return {
+    statusCode,
+    headers: CORS_HEADERS,
+    body: JSON.stringify({ error: message, ...extra }),
+  };
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const pool = await getPgPool();
+  const usingDb = Boolean(pool);
+
+  try {
+    if (event.httpMethod === 'GET') {
+      if (usingDb) {
+        const result = await pool.query(
+          'SELECT * FROM proposals ORDER BY created_at DESC LIMIT 200'
+        );
+        return ok(result.rows.map(rowToProposal));
+      }
+      return ok(memoryStore.list());
+    }
+
+    if (event.httpMethod === 'POST') {
+      const input = parseBody(event);
+      const proposal = buildProposal(input);
+      if (usingDb) {
+        const result = await pool.query(
+          `INSERT INTO proposals
+            (id, title, origin, destination, depart_date, return_date,
+             price_cents, currency, status, notes, payload)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+           RETURNING *`,
+          [
+            proposal.id,
+            proposal.title,
+            proposal.origin,
+            proposal.destination,
+            proposal.departDate,
+            proposal.returnDate,
+            proposal.priceCents,
+            proposal.currency,
+            proposal.status,
+            proposal.notes,
+            proposal.payload,
+          ]
+        );
+        return ok(rowToProposal(result.rows[0]), 201);
+      }
+      memoryStore.create(proposal);
+      return ok(proposal, 201);
+    }
+
+    if (event.httpMethod === 'PUT') {
+      const input = parseBody(event);
+      const id = input.id || extractIdFromPath(event);
+      if (!id) return fail(400, 'Missing proposal id');
+      const patch = {};
+      if (input.status !== undefined) {
+        if (!VALID_STATUSES.has(input.status)) {
+          return fail(400, `Invalid status. Allowed: ${[...VALID_STATUSES].join(', ')}`);
+        }
+        patch.status = input.status;
+      }
+      for (const key of ['title', 'notes', 'priceCents', 'payload']) {
+        if (input[key] !== undefined) patch[key] = input[key];
+      }
+      if (usingDb) {
+        const result = await pool.query(
+          `UPDATE proposals SET
+              title = COALESCE($2, title),
+              status = COALESCE($3, status),
+              notes = COALESCE($4, notes),
+              price_cents = COALESCE($5, price_cents),
+              payload = COALESCE($6, payload),
+              updated_at = NOW()
+           WHERE id = $1
+           RETURNING *`,
+          [
+            id,
+            patch.title ?? null,
+            patch.status ?? null,
+            patch.notes ?? null,
+            patch.priceCents ?? null,
+            patch.payload ?? null,
+          ]
+        );
+        if (result.rowCount === 0) return fail(404, 'Proposal not found');
+        return ok(rowToProposal(result.rows[0]));
+      }
+      const updated = memoryStore.update(id, patch);
+      if (!updated) return fail(404, 'Proposal not found');
+      return ok(updated);
+    }
+
+    if (event.httpMethod === 'DELETE') {
+      const id = extractIdFromPath(event);
+      if (!id) return fail(400, 'Missing proposal id');
+      if (usingDb) {
+        const result = await pool.query('DELETE FROM proposals WHERE id = $1', [id]);
+        if (result.rowCount === 0) return fail(404, 'Proposal not found');
+      } else if (!memoryStore.delete(id)) {
+        return fail(404, 'Proposal not found');
+      }
+      return ok({ id, deleted: true });
+    }
+
+    return fail(405, `Method ${event.httpMethod} not allowed`);
+  } catch (err) {
+    console.error('[proposals] handler error:', err);
+    return fail(500, err.message || 'Internal server error');
+  }
+};


### PR DESCRIPTION
The deployed /.netlify/functions/proposals endpoint was returning 502
with "No database configured. Set DB_HOST for Postgres in production."
because the Netlify alpha environment has no Postgres configured.

Add a proposals function that uses Postgres when DB_HOST is set and
falls back to a per-instance in-memory store otherwise, so the
endpoint stays usable in environments without a database. Supports
GET/POST/PUT/DELETE matching the proposals UI's API surface.