### PR TITLE
Live price polling on search flights page

### DIFF
--- a/src/components/LiveStatusIndicator.tsx
+++ b/src/components/LiveStatusIndicator.tsx
@@ -1,0 +1,30 @@
+interface LiveStatusIndicatorProps {
+  isRefreshing: boolean;
+  lastUpdated: Date | null;
+  intervalMs?: number;
+  className?: string;
+}
+
+export default function LiveStatusIndicator({
+  isRefreshing,
+  lastUpdated,
+  intervalMs = 5000,
+  className = '',
+}: LiveStatusIndicatorProps) {
+  const seconds = Math.round(intervalMs / 1000);
+  return (
+    <div className={`flex items-center text-xs text-gray-500 ${className}`}>
+      <span
+        className={`mr-2 inline-block h-2 w-2 rounded-full ${
+          isRefreshing ? 'bg-cyan-500 animate-pulse' : 'bg-emerald-500'
+        }`}
+        aria-hidden="true"
+      />
+      {isRefreshing
+        ? 'Refreshing…'
+        : `Live • auto-refreshes every ${seconds}s${
+            lastUpdated ? ` • updated ${lastUpdated.toLocaleTimeString()}` : ''
+          }`}
+    </div>
+  );
+}

--- a/src/hooks/useLivePolling.ts
+++ b/src/hooks/useLivePolling.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseLivePollingOptions {
+  enabled: boolean;
+  intervalMs?: number;
+  fetcher: () => Promise<void>;
+}
+
+interface UseLivePollingResult {
+  isRefreshing: boolean;
+  lastUpdated: Date | null;
+  markUpdated: () => void;
+}
+
+// Polls `fetcher` on an interval while `enabled` is true and the tab is
+// visible. Skips ticks if a previous fetch is still in flight.
+export function useLivePolling({
+  enabled,
+  intervalMs = 5000,
+  fetcher,
+}: UseLivePollingOptions): UseLivePollingResult {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const fetcherRef = useRef(fetcher);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
+
+  const markUpdated = useCallback(() => setLastUpdated(new Date()), []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+      if (inFlightRef.current) return;
+
+      inFlightRef.current = true;
+      setIsRefreshing(true);
+      try {
+        await fetcherRef.current();
+        if (!cancelled) setLastUpdated(new Date());
+      } finally {
+        inFlightRef.current = false;
+        if (!cancelled) setIsRefreshing(false);
+      }
+    };
+
+    const intervalId = window.setInterval(tick, intervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [enabled, intervalMs]);
+
+  return { isRefreshing, lastUpdated, markUpdated };
+}

--- a/src/pages/SearchFlightsPage.tsx
+++ b/src/pages/SearchFlightsPage.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { useLivePolling } from '../hooks/useLivePolling';
+import LiveStatusIndicator from '../components/LiveStatusIndicator';
 
 interface Airport {
   iataCode: string;
@@ -59,8 +61,6 @@ export default function SearchFlightsPage() {
   const [flights, setFlights] = useState<Flight[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const [isRefreshing, setIsRefreshing] = useState(false);
   const lastSearchParamsRef = useRef<{
     origin: string;
     destination: string;
@@ -250,10 +250,7 @@ export default function SearchFlightsPage() {
     options: { silent?: boolean } = {}
   ) => {
     const { silent = false } = options;
-
-    if (silent) {
-      setIsRefreshing(true);
-    } else {
+    if (!silent) {
       setIsSearching(true);
       setError(null);
     }
@@ -275,7 +272,6 @@ export default function SearchFlightsPage() {
         setError('No flights found. Please try different search criteria.');
         setFlights([]);
       }
-      setLastUpdated(new Date());
     } catch (err) {
       console.error('Error searching flights:', err);
       if (!silent) {
@@ -283,11 +279,7 @@ export default function SearchFlightsPage() {
         setFlights([]);
       }
     } finally {
-      if (silent) {
-        setIsRefreshing(false);
-      } else {
-        setIsSearching(false);
-      }
+      if (!silent) setIsSearching(false);
     }
   };
 
@@ -304,30 +296,20 @@ export default function SearchFlightsPage() {
     lastSearchParamsRef.current = params;
     setHasSearched(true);
     await fetchFlights(params);
+    markUpdated();
   };
 
-  // Poll for live price updates every 5 seconds after a search has been made.
-  // Pauses when the tab is hidden to avoid unnecessary API calls.
-  useEffect(() => {
-    if (!hasSearched || !lastSearchParamsRef.current) return;
+  const pollFetcher = useCallback(async () => {
+    if (isSearching) return;
+    if (!lastSearchParamsRef.current) return;
+    await fetchFlights(lastSearchParamsRef.current, { silent: true });
+  }, [isSearching]);
 
-    const POLL_INTERVAL_MS = 5000;
-    let cancelled = false;
-
-    const tick = () => {
-      if (cancelled) return;
-      if (document.visibilityState !== 'visible') return;
-      if (isSearching || isRefreshing) return;
-      if (!lastSearchParamsRef.current) return;
-      fetchFlights(lastSearchParamsRef.current, { silent: true });
-    };
-
-    const intervalId = window.setInterval(tick, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-    };
-  }, [hasSearched, isSearching, isRefreshing]);
+  const { isRefreshing, lastUpdated, markUpdated } = useLivePolling({
+    enabled: hasSearched,
+    intervalMs: 5000,
+    fetcher: pollFetcher,
+  });
 
   return (
     <div className="min-h-screen px-4 py-8 sm:p-8">
@@ -500,19 +482,11 @@ export default function SearchFlightsPage() {
                 Search Results {flights.length > 0 && `(${flights.length} found)`}
               </h2>
               {hasSearched && (
-                <div className="flex items-center text-xs text-gray-500">
-                  <span
-                    className={`mr-2 inline-block h-2 w-2 rounded-full ${
-                      isRefreshing ? 'bg-cyan-500 animate-pulse' : 'bg-emerald-500'
-                    }`}
-                    aria-hidden="true"
-                  />
-                  {isRefreshing
-                    ? 'Refreshing prices…'
-                    : `Live • auto-refreshes every 5s${
-                        lastUpdated ? ` • updated ${lastUpdated.toLocaleTimeString()}` : ''
-                      }`}
-                </div>
+                <LiveStatusIndicator
+                  isRefreshing={isRefreshing}
+                  lastUpdated={lastUpdated}
+                  intervalMs={5000}
+                />
               )}
             </div>
             

--- a/src/pages/SearchFlightsPage.tsx
+++ b/src/pages/SearchFlightsPage.tsx
@@ -58,6 +58,16 @@ export default function SearchFlightsPage() {
   const [isSearching, setIsSearching] = useState(false);
   const [flights, setFlights] = useState<Flight[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const lastSearchParamsRef = useRef<{
+    origin: string;
+    destination: string;
+    departureDate: string;
+    returnDate?: string;
+    tripType: 'one-way' | 'round-trip';
+  } | null>(null);
 
   // Airport search states
   const [originInput, setOriginInput] = useState('JFK');
@@ -229,41 +239,95 @@ export default function SearchFlightsPage() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const fetchFlights = async (
+    params: {
+      origin: string;
+      destination: string;
+      departureDate: string;
+      returnDate?: string;
+      tripType: 'one-way' | 'round-trip';
+    },
+    options: { silent?: boolean } = {}
+  ) => {
+    const { silent = false } = options;
+
+    if (silent) {
+      setIsRefreshing(true);
+    } else {
+      setIsSearching(true);
+      setError(null);
+    }
+
+    try {
+      const response = await axios.post('/.netlify/functions/search-flights', {
+        origin: params.origin.toUpperCase(),
+        destination: params.destination.toUpperCase(),
+        departureDate: params.departureDate,
+        returnDate: params.tripType === 'round-trip' ? params.returnDate : undefined,
+        maxResults: 10,
+        nonStop: false
+      });
+
+      if (response.data && response.data.data) {
+        setFlights(response.data.data);
+        setError(null);
+      } else if (!silent) {
+        setError('No flights found. Please try different search criteria.');
+        setFlights([]);
+      }
+      setLastUpdated(new Date());
+    } catch (err) {
+      console.error('Error searching flights:', err);
+      if (!silent) {
+        setError('Failed to search for flights. Please try again later.');
+        setFlights([]);
+      }
+    } finally {
+      if (silent) {
+        setIsRefreshing(false);
+      } else {
+        setIsSearching(false);
+      }
+    }
+  };
+
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    
+
     if (!origin || !destination || !departureDate || (tripType === 'round-trip' && !returnDate)) {
       setError('Please fill in all required fields');
       return;
     }
-    
-    setIsSearching(true);
-    
-    try {
-      const response = await axios.post('/.netlify/functions/search-flights', {
-        origin: origin.toUpperCase(),
-        destination: destination.toUpperCase(),
-        departureDate,
-        returnDate: tripType === 'round-trip' ? returnDate : undefined,
-        maxResults: 10,
-        nonStop: false
-      });
-      
-      if (response.data && response.data.data) {
-        setFlights(response.data.data);
-      } else {
-        setError('No flights found. Please try different search criteria.');
-        setFlights([]);
-      }
-    } catch (err) {
-      console.error('Error searching flights:', err);
-      setError('Failed to search for flights. Please try again later.');
-      setFlights([]);
-    } finally {
-      setIsSearching(false);
-    }
+
+    const params = { origin, destination, departureDate, returnDate, tripType };
+    lastSearchParamsRef.current = params;
+    setHasSearched(true);
+    await fetchFlights(params);
   };
+
+  // Poll for live price updates every 5 seconds after a search has been made.
+  // Pauses when the tab is hidden to avoid unnecessary API calls.
+  useEffect(() => {
+    if (!hasSearched || !lastSearchParamsRef.current) return;
+
+    const POLL_INTERVAL_MS = 5000;
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') return;
+      if (isSearching || isRefreshing) return;
+      if (!lastSearchParamsRef.current) return;
+      fetchFlights(lastSearchParamsRef.current, { silent: true });
+    };
+
+    const intervalId = window.setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [hasSearched, isSearching, isRefreshing]);
 
   return (
     <div className="min-h-screen px-4 py-8 sm:p-8">
@@ -431,9 +495,26 @@ export default function SearchFlightsPage() {
           
           {/* Search results */}
           <div className="mt-8">
-            <h2 className="text-lg font-medium text-gray-900 mb-4">
-              Search Results {flights.length > 0 && `(${flights.length} found)`}
-            </h2>
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-medium text-gray-900">
+                Search Results {flights.length > 0 && `(${flights.length} found)`}
+              </h2>
+              {hasSearched && (
+                <div className="flex items-center text-xs text-gray-500">
+                  <span
+                    className={`mr-2 inline-block h-2 w-2 rounded-full ${
+                      isRefreshing ? 'bg-cyan-500 animate-pulse' : 'bg-emerald-500'
+                    }`}
+                    aria-hidden="true"
+                  />
+                  {isRefreshing
+                    ? 'Refreshing prices…'
+                    : `Live • auto-refreshes every 5s${
+                        lastUpdated ? ` • updated ${lastUpdated.toLocaleTimeString()}` : ''
+                      }`}
+                </div>
+              )}
+            </div>
             
             {error && (
               <div className="bg-red-50 border-l-4 border-red-400 p-4 mb-6">


### PR DESCRIPTION
## Summary
- After the user runs a search on `/search`, results auto-refresh every 5 seconds so prices stay live without any manual action.
- Polling pauses while the browser tab is hidden (uses `document.visibilityState`) to avoid unnecessary Amadeus API calls.
- Adds a small status indicator in the results header showing refresh state and the last-updated timestamp.

## Implementation notes
- Refactored search into a reusable `fetchFlights(params, { silent })` helper. Background polls run with `silent: true`, which keeps existing flight rows visible (no spinner replacing the list) and suppresses transient errors.
- The most recent search params are tracked via a ref so the interval always re-fetches the same query the user submitted.
- Polling only starts after the first user-initiated search and is cleaned up on unmount / dep changes.

## Test plan
- [ ] Visit `/search`, run a search, confirm results render
- [ ] Observe "Live • auto-refreshes every 5s" indicator and the timestamp updating roughly every 5s
- [ ] Switch to another tab for ~30s, return, and confirm polling resumes (no burst of queued calls)
- [ ] Confirm a transient backend failure during a background poll does not wipe out the existing results

---
_Generated by [Claude Code](https://claude.ai/code/session_014h2rzSJR8i7Zedee5ZmodK)_